### PR TITLE
Check min pickup age before swapping a held object (with a ground tra…

### DIFF
--- a/server/server.cpp
+++ b/server/server.cpp
@@ -15103,7 +15103,13 @@ int main() {
                                             // can treat it like a swap
 
                                     
-                                            if( ! targetObj->permanent ) {
+                                            if( ! targetObj->permanent
+                                                &&
+                                                canPickup( 
+                                                    targetObj->id,
+                                                    computeAge( 
+                                                        nextPlayer ) ) ) {
+                                                
                                                 // target can be picked up
 
                                                 // "set-down" type bare ground 


### PR DESCRIPTION
…nsition) with another object on the ground.  A child can no longer swap a clean pad with a sword, car, bow, etc.  Fixes #378