### PR TITLE
Added weighting for mothers based on age

### DIFF
--- a/server/server.cpp
+++ b/server/server.cpp
@@ -5883,6 +5883,10 @@ int processLoggedInPlayer( char inAllowReconnect,
             continue;
             }
 
+	if( player->isEve && ( player->familyName == NULL ) ) {
+            continue;
+            }//skips over players who do not name themselves. helps new player spawn on mothers who are not just playing solo.
+
         if( player->vogMode ) {
             continue;
             }

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -6307,6 +6307,16 @@ int processLoggedInPlayer( char inAllowReconnect,
                 // temp part of weight
                 totalWeight += 0.5 - fabs( p->heat - 0.5 );
                 
+                // this section adds a weighting based on age, younger more likely to have children, currently the rate seems to be a ratio around 6:1 children for young:old parents with no extra weight from yum or temp.
+                double age = computeAge(p);
+
+                if (age <= 45) {
+                    totalWeight += 0.5;
+                }
+
+                if (age <= 25) {
+                    totalWeight += 1.0;
+                }
 
                 int yumMult = p->yummyFoodChain.size() - 1;
                                 
@@ -6329,6 +6339,18 @@ int processLoggedInPlayer( char inAllowReconnect,
 
                 totalWeight += 0.5 - fabs( p->heat - 0.5 );
 
+                // repeated in this section, as the weighting system needs both totalWeight and Chance to have the same max value or else it crashes the server when trying to have a child.
+                double age = computeAge(p);
+
+                if (age <= 45) {
+                    totalWeight += 0.5;
+                }
+
+                if (age <= 25) {
+                    totalWeight += 1.0;
+                }
+		// current ~ratio of children netween 2 parents, one young and one old, is around 6:1 with Weight values set to current values based on age. ~3:1 ratio if age <= 25 totalWeight is set to 0.5
+		// only tested with 2 parents, with birthcooldown disabled, so if the young parent just had a kid, and another player joins, then the older will be chosen regardless of weighting.
 
                 int yumMult = p->yummyFoodChain.size() - 1;
                                 


### PR DESCRIPTION
Added the weighting into the currently implemented base game weighting system that weights parents for children based on yum and heat.

Makes it so parents that are younger then 45 and even more so when younger then 25, more likely to be chosen as a parent.

Current Ratio seems to be around a 6:1 young:old parent having child with no other heat or yum modifiers. Change the totalWeight value under age <= 25 or age <= 45 to different values to balance rates. Or change ages to what might work better, or what you would feel is better. Other ratio that was tested is listed in comment in code.

Tested as extensively as 1 person can
Used 3 clients, and tested between 2 parents at both age groups, one young (<45 and <25) and one old (>25 and >45) and 1 child respawning continuously.

Numbers for ratio is only gotten from observation in game, no actual systematized math based on the rng system being used by the game was done to arrive at that number, so ratio is only roughly, and take with a grain of salt the size of texas.

Thanks to Adk for guiding me through linux, building of the server on my end so that I can test my changes, and fixing the computeAge that I messed up on initially.