### PR TITLE
Minitech: An in-game crafting guide

### DIFF
--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -21029,6 +21029,8 @@ void LivingLifePage::keyDown( unsigned char inASCII ) {
                                     // not blank
                                     mHintFilterString = 
                                         stringDuplicate( trimmedFilterString );
+										
+									minitech::hintStr = mHintFilterString;
                                     }
                             
                                 delete [] trimmedFilterString;

--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -53,7 +53,7 @@
 
 static ObjectPickable objectPickable;
 
-
+#include "minitech.h"
 
 #define MAP_D 64
 #define MAP_NUM_CELLS 4096
@@ -76,6 +76,7 @@ static float pencilErasedFontExtraFade = 0.75;
 
 
 extern doublePair lastScreenViewCenter;
+doublePair LivingLifePage::minitechGetLastScreenViewCenter() { return lastScreenViewCenter; }
 
 static char shouldMoveCamera = true;
 
@@ -896,7 +897,13 @@ static char *getDisplayObjectDescription( int inID ) {
     return upper;
     }
 
-
+char *LivingLifePage::minitechGetDisplayObjectDescription( int objId ) { 
+    ObjectRecord *o = getObject( objId );
+    if( o == NULL ) {
+		return "";
+    }
+	return getDisplayObjectDescription(objId);
+}
 
 typedef enum messageType {
     SHUTDOWN,
@@ -2489,6 +2496,14 @@ LivingLifePage::LivingLifePage()
     if( ! tutorialDone ) {
         mTutorialNumber = 1;
         }
+		
+	minitech::setLivingLifePage(
+		this, 
+		&gameObjects, 
+		mMapD, 
+		pathFindingD, 
+		mMapContainedStacks, 
+		mMapSubContainedStacks);
     }
 
 
@@ -7825,7 +7840,7 @@ void LivingLifePage::draw( doublePair inViewCenter,
     for( int i=0; i<NUM_HINT_SHEETS; i++ ) {
         if( ! equal( mHintPosOffset[i], mHintHideOffset[i] ) 
             &&
-            mHintMessage[i] != NULL ) {
+            mHintMessage[i] != NULL && !minitech::minitechEnabled ) {
             
             doublePair hintPos  = 
                 add( mHintPosOffset[i], lastScreenViewCenter );
@@ -8816,6 +8831,14 @@ void LivingLifePage::draw( doublePair inViewCenter,
             }
         }
 
+	// minitech
+	float worldMouseX, worldMouseY;
+	getLastMouseScreenPos( &lastScreenMouseX, &lastScreenMouseY );
+	screenToWorld( lastScreenMouseX,
+				   lastScreenMouseY,
+				   &worldMouseX,
+				   &worldMouseY );
+	minitech::livingLifeDraw(worldMouseX, worldMouseY);
     
     if( vogMode ) {
         // draw again, so we can see picker
@@ -11133,7 +11156,7 @@ void LivingLifePage::step() {
         sendToServerSocket( (char*)"KA 0 0#" );
         }
     
-
+	minitech::livingLifeStep();
 
     char *message = getNextServerMessage();
 
@@ -12280,6 +12303,8 @@ void LivingLifePage::step() {
                 
                 if( !( mFirstServerMessagesReceived & 1 ) ) {
                     // first map chunk just recieved
+					
+					minitech::initOnBirth();
                     
                     char found = false;
                     int closestX = 0;
@@ -13820,8 +13845,9 @@ void LivingLifePage::step() {
                             mNextHintObjectID = existing->holdingID;
                             mNextHintIndex = 
                                 mHintBookmarks[ mNextHintObjectID ];
+								
+							minitech::currentHintObjId = mNextHintObjectID;
                             }
-                        
 
 
                         ObjectRecord *newClothing = 
@@ -15295,6 +15321,7 @@ void LivingLifePage::step() {
                 ourID = ourObject->id;
 
                 if( ourID != lastPlayerID ) {
+					minitech::initOnBirth();
                     // different ID than last time, delete old home markers
                     oldHomePosStack.deleteAll();
                     }
@@ -19104,6 +19131,8 @@ char LivingLifePage::getCellBlocksWalking( int inMapX, int inMapY ) {
 
 
 void LivingLifePage::pointerDown( float inX, float inY ) {
+	if (minitech::livingLifePageMouseDown( inX, inY )) return;
+	
     lastMouseX = inX;
     lastMouseY = inY;
 
@@ -19561,17 +19590,20 @@ void LivingLifePage::pointerDown( float inX, float inY ) {
                 // give hint about dest object which will be unchanged 
                 mNextHintObjectID = destID;
                 mNextHintIndex = mHintBookmarks[ destID ];
+				minitech::currentHintObjId = destID;
                 }
             else if( tr->newActor > 0 && 
                      ourLiveObject->holdingID != tr->newActor ) {
                 // give hint about how what we're holding will change
                 mNextHintObjectID = tr->newActor;
                 mNextHintIndex = mHintBookmarks[ tr->newTarget ];
+				minitech::currentHintObjId = tr->newActor;
                 }
             else if( tr->newTarget > 0 ) {
                 // give hint about changed target after we act on it
                 mNextHintObjectID = tr->newTarget;
                 mNextHintIndex = mHintBookmarks[ tr->newTarget ];
+				minitech::currentHintObjId = tr->newTarget;
                 }
             }
         else {
@@ -19581,6 +19613,7 @@ void LivingLifePage::pointerDown( float inX, float inY ) {
             if( getTrans( 0, destID ) == NULL ) {
                 mNextHintObjectID = destID;
                 mNextHintIndex = mHintBookmarks[ destID ];
+				minitech::currentHintObjId = destID;
                 }
             }
         }
@@ -20645,6 +20678,7 @@ void LivingLifePage::keyDown( unsigned char inASCII ) {
         return;
         }
 
+	if (minitech::livingLifeKeyDown(inASCII)) return;
     
     switch( inASCII ) {
         /*

--- a/gameSource/LivingLifePage.h
+++ b/gameSource/LivingLifePage.h
@@ -471,6 +471,8 @@ class LivingLifePage : public GamePage, public ActionListener {
             return mRequiredVersion;
             }
 
+		doublePair minitechGetLastScreenViewCenter();
+		char *minitechGetDisplayObjectDescription(int objId);
 
         virtual void actionPerformed( GUIComponent *inTarget );
         
@@ -519,9 +521,9 @@ class LivingLifePage : public GamePage, public ActionListener {
 
 
         int mMapD;
-
+		public: // minitech
         int *mMap;
-        
+        protected: // minitech
         int *mMapBiomes;
         int *mMapFloors;
 
@@ -574,10 +576,10 @@ class LivingLifePage : public GamePage, public ActionListener {
         SimpleVector<int> mMapExtraMovingObjectsDestObjectIDs;
         SimpleVector<ExtraMapObject> mMapExtraMovingObjects;
 
-        
+        public: // minitech
         int mMapOffsetX;
         int mMapOffsetY;
-
+		protected: // minitech
 
         char mEKeyEnabled;
         char mEKeyDown;
@@ -845,10 +847,10 @@ class LivingLifePage : public GamePage, public ActionListener {
         char mForceGroundClick;
         
 
-
+		public: // minitech
         LiveObject *getOurLiveObject();
         LiveObject *getLiveObject( int inID );
-        
+        protected: // minitech
 
         void clearLiveObjects();
         

--- a/gameSource/makeFileList
+++ b/gameSource/makeFileList
@@ -14,6 +14,7 @@ ROOT_PATH = ../..
 
 
 LAYER_SOURCE = \
+minitech.cpp \
 game.cpp \
 spriteBank.cpp \
 objectBank.cpp \

--- a/gameSource/minitech.cpp
+++ b/gameSource/minitech.cpp
@@ -1,0 +1,1217 @@
+
+#include <windows.h>
+#include <vector>
+#include <string>
+#include <numeric> //iota
+#include <cmath> //pow and sqrt
+#include <algorithm> //vector sort
+
+#include "LivingLifePage.h"
+#include "groundSprites.h"
+#include "objectBank.h"
+#include "categoryBank.h"
+
+#include "minorGems/util/SimpleVector.h"
+#include "minorGems/game/drawUtils.h"
+#include "minorGems/game/Font.h"
+// #include "minorGems/util/SettingsManager.h"
+
+
+#include "minitech.h"
+
+using namespace std;
+
+bool minitech::minitechEnabled = true;
+float minitech::guiScale = 1.0f;
+
+float minitech::viewWidth = 1280.0;
+float minitech::viewHeight = 720.0;
+
+Font *minitech::handwritingFont;
+Font *minitech::mainFont;
+Font *minitech::tinyHandwritingFont;
+Font *minitech::tinyMainFont;
+
+LivingLifePage *minitech::livingLifePage;
+LiveObject *minitech::ourLiveObject;
+SimpleVector<LiveObject> *minitech::players;
+int minitech::mMapD;
+int minitech::pathFindingD;
+int minitech::maxObjects;
+SimpleVector<int> *minitech::mMapContainedStacks;
+SimpleVector<SimpleVector<int>> *minitech::mMapSubContainedStacks;
+
+bool minitech::minitechMinimized = true;
+int minitech::stepCount;
+float minitech::currentX;
+float minitech::currentY;
+
+vector<TransRecord*> minitech::currentHintTrans;
+int minitech::currentTwoTechPage;
+int minitech::useOrMake;
+int minitech::lastUseOrMake;
+int minitech::currentHintObjId;
+int minitech::lastHintObjId;
+vector<minitech::mouseListener*> minitech::twotechMouseListeners;
+minitech::mouseListener* minitech::prevListener;
+minitech::mouseListener* minitech::nextListener;
+
+
+
+void minitech::setLivingLifePage(
+	LivingLifePage *inLivingLifePage, 
+	SimpleVector<LiveObject> *inGameObjects, 
+	int inmMapD, 
+	int inPathFindingD,
+	SimpleVector<int> *inmMapContainedStacks,
+	SimpleVector<SimpleVector<int>> *inmMapSubContainedStacks
+	) {
+	
+	maxObjects = getMaxObjectID() + 1;
+	livingLifePage = inLivingLifePage;
+	players = inGameObjects;
+	mMapD = inmMapD;
+	pathFindingD = inPathFindingD;
+	mMapContainedStacks = inmMapContainedStacks;
+	mMapSubContainedStacks = inmMapSubContainedStacks;
+}
+
+void minitech::initOnBirth() { 
+	
+	for (auto p: twotechMouseListeners) {
+		delete(p);
+	}
+	twotechMouseListeners.clear();
+	twotechMouseListeners.shrink_to_fit();
+	
+	currentHintTrans.clear();
+	currentHintTrans.shrink_to_fit();
+	
+	if (prevListener != NULL) delete(prevListener);
+	if (nextListener != NULL) delete(nextListener);
+	prevListener = NULL;
+	nextListener = NULL;
+	
+	if (handwritingFont != NULL) delete handwritingFont;
+	if (mainFont != NULL) delete mainFont;
+	if (tinyHandwritingFont != NULL) delete tinyHandwritingFont;
+	if (tinyMainFont != NULL) delete tinyMainFont;
+	handwritingFont = new Font( "font_handwriting_32_32.tga", 3, 6, false, 16*guiScale );
+	handwritingFont->setMinimumPositionPrecision( 1 );
+	mainFont = new Font( getFontTGAFileName(), 6, 16, false, 16*guiScale );
+	mainFont->setMinimumPositionPrecision( 1 );	
+	tinyHandwritingFont = new Font( "font_handwriting_32_32.tga", 3, 6, false, 16/2*guiScale );
+	tinyHandwritingFont->setMinimumPositionPrecision( 1 );
+	tinyMainFont = new Font( getFontTGAFileName(), 6, 16, false, 16/2*guiScale );
+	tinyMainFont->setMinimumPositionPrecision( 1 );
+
+}
+
+
+
+bool minitech::posWithinArea(doublePair pos, doublePair areaTL, doublePair areaBR) {
+	return 
+		pos.x >= areaTL.x &&
+		pos.x <= areaBR.x &&
+		pos.y <= areaTL.y &&
+		pos.y >= areaBR.y;
+}
+
+bool minitech::posEqual(doublePair pos1, doublePair pos2) {
+	return 
+		pos1.x == pos2.x &&
+		pos1.y == pos2.y;
+}
+
+int minitech::getDummyParent(int objId) {
+	if (objId <= 0 || objId >= maxObjects) return objId;
+	ObjectRecord* o = getObject(objId);
+	if (o != NULL) {
+		if (o->isUseDummy) return o->useDummyParent;
+	}
+	return objId;
+}
+
+bool minitech::isCategory(int objId) {
+	if (objId <= 0) return false;
+	CategoryRecord *c = getCategory( objId );
+	return c != NULL;
+}
+
+minitech::mouseListener* minitech::getMouseListenerByArea( 
+	vector<mouseListener*>* listeners, doublePair posTL, doublePair posBR ) {
+	for (int i=0; i<listeners->size(); i++) {
+		if (
+			posEqual( (*listeners)[i]->posTL, posTL) &&
+			posEqual( (*listeners)[i]->posBR, posBR)
+			) {
+			return (*listeners)[i];
+		}
+	}
+	mouseListener* listener = new mouseListener();
+	listener->posTL = posTL;
+	listener->posBR = posBR;
+	listener->mouseHover = false;
+	listeners->push_back(listener);
+	return listener;
+}
+
+GridPos minitech::getClosestTile(GridPos src, int objId) {
+	
+	int *mMap = livingLifePage->mMap;
+		
+	int mMapOffsetX = livingLifePage->mMapOffsetX;
+	int mMapOffsetY = livingLifePage->mMapOffsetY;
+	
+	int pathOffsetX = pathFindingD/2 - currentX;
+	int pathOffsetY = pathFindingD/2 - currentY;
+	
+	float foundBestDist = 9999;
+	float foundBestX, foundBestY;
+	
+	bool tileFound = false;
+
+	for( int y=0; y<pathFindingD; y++ ) {
+		int mapY = ( y - pathOffsetY ) + mMapD / 2 - mMapOffsetY;
+		int mapY_abs = mapY + mMapOffsetY - mMapD / 2;
+		
+		for( int x=0; x<pathFindingD; x++ ) {
+			int mapX = ( x - pathOffsetX ) + mMapD / 2 - mMapOffsetX;
+			int mapX_abs = mapX + mMapOffsetX - mMapD / 2;
+			
+			if( mapY >= 0 && mapY < mMapD &&
+				mapX >= 0 && mapX < mMapD ) { 
+
+				bool foundInThisTile = false;
+
+				int mapI = mapY * mMapD + mapX;
+				int id = mMap[mapI];
+				id = getDummyParent(id);
+
+				if (id == objId) {
+					float foundDist = sqrt(pow(src.y - mapY_abs, 2) + pow(src.x - mapX_abs, 2));
+					if (foundDist < foundBestDist) {
+						tileFound = true;
+						foundInThisTile = true;
+						foundBestX = mapX_abs;
+						foundBestY = mapY_abs;
+						foundBestDist = foundDist;
+						continue;
+					}
+				}
+				
+				if (mMapContainedStacks[mapI].size() > 0) {
+					for (int i=0; i < mMapContainedStacks[mapI].size(); i++) {
+						id = mMapContainedStacks[mapI].getElementDirect(i);
+						id = getDummyParent(id);
+						if (id == objId) {
+							float foundDist = sqrt(pow(src.y - mapY_abs, 2) + pow(src.x - mapX_abs, 2));
+							if (foundDist < foundBestDist) {
+								tileFound = true;
+								foundInThisTile = true;
+								foundBestX = mapX_abs;
+								foundBestY = mapY_abs;
+								foundBestDist = foundDist;
+							}
+						}
+					}
+					if (foundInThisTile) continue;
+				}
+				
+				if (mMapSubContainedStacks[mapI].size() > 0) {
+					for (int i=0; i < mMapSubContainedStacks[mapI].size(); i++) {
+						SimpleVector<int> subContainedStack = mMapSubContainedStacks[mapI].getElementDirect(i);
+						for (int k=0; k < subContainedStack.size(); k++) {
+							id = subContainedStack.getElementDirect(k);
+							id = getDummyParent(id);
+							if (id == objId) {
+								float foundDist = sqrt(pow(src.y - mapY_abs, 2) + pow(src.x - mapX_abs, 2));
+								if (foundDist < foundBestDist) {
+									tileFound = true;
+									foundInThisTile = true;
+									foundBestX = mapX_abs;
+									foundBestY = mapY_abs;
+									foundBestDist = foundDist;
+								}
+							}
+						}
+					}
+					if (foundInThisTile) continue;
+				}
+				
+			}
+		}
+	}
+	
+	GridPos foundPos = {9999, 9999};
+	if (tileFound) {
+		foundPos = {foundBestX, foundBestY};
+	}
+	return foundPos;
+}
+
+
+
+int minitech::objIdFromXY( int x, int y ) {
+	int mMapOffsetX = livingLifePage->mMapOffsetX;
+	int mMapOffsetY = livingLifePage->mMapOffsetY;
+	int *mMap = livingLifePage->mMap;
+	int mapX = x - mMapOffsetX + mMapD / 2;
+	int mapY = y - mMapOffsetY + mMapD / 2;
+	return mMap[ mapY * mMapD + mapX ];
+}
+
+vector<bool> minitech::getObjIsCloseVector() {
+	
+	vector<bool> objIsClose(maxObjects, false);
+	
+	int *mMap = livingLifePage->mMap;
+		
+	int mMapOffsetX = livingLifePage->mMapOffsetX;
+	int mMapOffsetY = livingLifePage->mMapOffsetY;
+	
+	int pathOffsetX = pathFindingD/2 - currentX;
+	int pathOffsetY = pathFindingD/2 - currentY;
+	
+	for( int y=0; y<pathFindingD; y++ ) {
+		int mapY = ( y - pathOffsetY ) + mMapD / 2 - mMapOffsetY;
+		int mapY_abs = mapY + mMapOffsetY - mMapD / 2;
+		
+		for( int x=0; x<pathFindingD; x++ ) {
+			int mapX = ( x - pathOffsetX ) + mMapD / 2 - mMapOffsetX;
+			int mapX_abs = mapX + mMapOffsetX - mMapD / 2;
+			
+			if( mapY >= 0 && mapY < mMapD &&
+				mapX >= 0 && mapX < mMapD ) { 
+				
+				bool foundInThisTile = false;
+				
+				int mapI = mapY * mMapD + mapX;
+				int id = mMap[mapI];
+				
+				if ( ! (!id || id <= 0 || id >= maxObjects) ) {
+					objIsClose[id] = true;
+					foundInThisTile = true;
+				}
+				
+				if (mMapContainedStacks[mapI].size() > 0) {
+					for (int i=0; i < mMapContainedStacks[mapI].size(); i++) {
+						id = mMapContainedStacks[mapI].getElementDirect(i);
+						objIsClose[id] = true;
+						foundInThisTile = true;
+					}
+					if (foundInThisTile) continue;
+				}
+				
+				if (mMapSubContainedStacks[mapI].size() > 0) {
+					for (int i=0; i < mMapSubContainedStacks[mapI].size(); i++) {
+						SimpleVector<int> subContainedStack = mMapSubContainedStacks[mapI].getElementDirect(i);
+						for (int k=0; k < subContainedStack.size(); k++) {
+							id = subContainedStack.getElementDirect(k);
+							objIsClose[id] = true;
+							foundInThisTile = true;
+						}
+					}
+					if (foundInThisTile) continue;
+				}
+				
+			}
+		}
+	}
+	return objIsClose;
+}
+
+vector<TransRecord*> minitech::getUsesTrans(int objId) {
+	
+	SimpleVector<TransRecord*> *usesTrans = getAllUses( objId );
+	vector<TransRecord*> results;
+	
+	int numTrans = 0;
+	if( usesTrans != NULL ) {
+		numTrans = usesTrans->size();
+	}
+	if( numTrans == 0 ) {
+		return results; 
+	}
+
+	for( int t=0; t<numTrans; t++ ) {
+		
+		TransRecord *trans = usesTrans->getElementDirect( t );
+		
+		int idA = trans->actor;
+		int idB = trans->target;
+		int idC = trans->newActor;
+		int idD = trans->newTarget;
+		
+		// if ( idA < 0 || idB < 0 ) continue;
+		
+		bool isUseDummyA = false;
+		bool isUseDummyB = false;
+		bool isUseDummyC = false;
+		bool isUseDummyD = false;
+		
+		if ( idA > 0 ) {
+			ObjectRecord* a = getObject(idA);
+			isUseDummyA = a->isUseDummy;
+		}
+		if ( idB > 0 ) {
+			ObjectRecord* b = getObject(idB);
+			isUseDummyB = b->isUseDummy;
+		}
+		if ( idC > 0 ) {
+			ObjectRecord* c = getObject(idC);
+			isUseDummyC = c->isUseDummy;
+		}
+		if ( idD > 0 ) {
+			ObjectRecord* d = getObject(idD);
+			isUseDummyD = d->isUseDummy;
+		}
+		if ( isUseDummyA || isUseDummyB ) continue;
+		
+		if ( isCategory(idA) || isCategory(idB) || isCategory(idC) || isCategory(idD) ) continue;
+		if ( trans->lastUseActor || trans->lastUseTarget ) continue;
+		
+		results.push_back(trans);
+
+	}
+	
+	return results;
+}
+
+vector<TransRecord*> minitech::getProdTrans(int objId) {
+	
+	SimpleVector<TransRecord*> *prodTrans = getAllProduces( objId );
+	vector<TransRecord*> results;
+	
+	int numTrans = 0;
+	if( prodTrans != NULL ) {
+		numTrans = prodTrans->size();
+	}
+	if( numTrans == 0 ) {
+		return results; 
+	}
+
+	for( int t=0; t<numTrans; t++ ) {
+		
+		TransRecord *trans = prodTrans->getElementDirect( t );
+		
+		int idA = trans->actor;
+		int idB = trans->target;
+		int idC = trans->newActor;
+		int idD = trans->newTarget;
+		
+		if ( idA == objId || idB == objId ) continue;
+		
+		bool isUseDummyA = false;
+		bool isUseDummyB = false;
+		bool isUseDummyC = false;
+		bool isUseDummyD = false;
+		
+		if ( idA > 0 ) {
+			ObjectRecord* a = getObject(idA);
+			isUseDummyA = a->isUseDummy;
+		}
+		if ( idB > 0 ) {
+			ObjectRecord* b = getObject(idB);
+			isUseDummyB = b->isUseDummy;
+		}
+		if ( idC > 0 ) {
+			ObjectRecord* c = getObject(idC);
+			isUseDummyC = c->isUseDummy;
+		}
+		if ( idD > 0 ) {
+			ObjectRecord* d = getObject(idD);
+			isUseDummyD = d->isUseDummy;
+		}
+		if ( isUseDummyA || isUseDummyB ) continue;
+		
+		if ( isCategory(idA) || isCategory(idB) || isCategory(idC) || isCategory(idD) ) continue;
+		if ( trans->lastUseActor || trans->lastUseTarget ) continue;
+		
+		results.push_back(trans);
+
+	}
+	
+	return results;
+}
+
+
+
+void minitech::drawPoint(doublePair posCen, string color) {
+	float pointSize = 3 * guiScale;
+	
+	if (color == "red") setDrawColor( 1, 0, 0, 1 );
+	if (color == "green") setDrawColor( 0, 1, 0, 1 );
+	if (color == "blue") setDrawColor( 0, 0, 1, 1 );
+	
+	drawRect( posCen, pointSize, pointSize );	
+}
+
+void minitech::drawObj(doublePair posCen, int objId, string strDescFirstLine, string strDescSecondLine) {
+	ObjectRecord* obj = getObject(objId);
+	if (objId <= 0) {
+		string firstPart;
+		string secondPart;
+		if (strDescFirstLine != "" && strDescSecondLine != "" ) {
+			firstPart = strDescFirstLine;
+			secondPart = strDescSecondLine;
+		} else {
+			firstPart = "EMPTY";
+			secondPart = "HAND";
+		}
+		doublePair firstLine = posCen;
+		int tinyLineHeight = 12;
+		firstLine.y += tinyLineHeight/2*guiScale;
+		drawStr(firstPart, firstLine, "tinyHandwritten", false);
+		firstLine.y -= tinyLineHeight*guiScale;
+		drawStr(secondPart, firstLine, "tinyHandwritten", false);
+		return;
+	}
+	if (obj == NULL) return;
+	int maxD = getMaxDiameter( obj );
+	double zoom = 1;
+	float maxSize = 76.0;
+	if( maxD > maxSize ) zoom = maxSize / maxD;
+	zoom = zoom * guiScale;
+	doublePair posAfterOffset = sub (posCen, mult( getObjectCenterOffset( obj ), zoom ));
+	drawObject( obj, 2, posAfterOffset, 0, false, false, 20, 0, false, false,
+				getEmptyClothingSet(), zoom );
+}
+
+void minitech::drawStr(
+	string str, doublePair posCen, string font, 
+	bool withBackground, bool avoidOffScreen) {
+	
+	doublePair screenCenter = livingLifePage->minitechGetLastScreenViewCenter();
+	
+	char sBuf[64];
+	sprintf( sBuf, str.c_str() );
+	float textWidth = 0;
+	if (font == "handwritten") {
+		textWidth = handwritingFont->measureString( sBuf );
+	} else if (font == "main") {
+		textWidth = mainFont->measureString( sBuf );
+	} else if (font == "tinyHandwritten") {
+		textWidth = tinyHandwritingFont->measureString( sBuf );
+	} else if (font == "tinyMain") {
+		textWidth = tinyMainFont->measureString( sBuf );
+	}
+	
+	float lineHeight = 24*guiScale;
+	float padding = 12*guiScale;
+	
+	if (font == "tinyHandwritten" || font == "tinyMain") {
+		lineHeight = lineHeight * 0.5;
+		padding = padding * 0.5;
+	}
+	
+	float recWidth = textWidth + padding*2;
+	float recHeight = 1 * lineHeight + padding*2;
+	
+	doublePair posLT = {posCen.x - recWidth/2, posCen.y + recHeight/2};	
+	
+	if (avoidOffScreen) {
+		doublePair offset = {0.0, 0.0};
+		if (posLT.x + recWidth > screenCenter.x + viewWidth/2) {
+			offset.x = screenCenter.x + viewWidth/2 - recWidth - posLT.x;
+		} else if (posLT.x < screenCenter.x - viewWidth/2) {
+			offset.x = - posLT.x + screenCenter.x - viewWidth/2;
+		}
+		if (posLT.y > screenCenter.y + viewHeight/2) {
+			offset.y = screenCenter.y + viewHeight/2 - posLT.y;
+		} else if (posLT.y - recHeight < screenCenter.y - viewHeight/2) {
+			offset.y = recHeight - posLT.y + screenCenter.y - viewHeight/2;
+		}
+		posLT = add(posLT, offset);
+		posCen = add(posCen, offset);
+	}
+	
+	doublePair textPos = {posLT.x + padding, posCen.y};
+	
+	if (withBackground) {
+		setDrawColor( 0, 0, 0, 0.8 );
+		drawRect( posCen, recWidth/2, recHeight/2);
+	}
+	
+	setDrawColor( 1, 1, 1, 1 );
+	if (font == "handwritten") {
+		handwritingFont->drawString( sBuf, textPos, alignLeft );
+	} else if (font == "main") {
+		mainFont->drawString( sBuf, textPos, alignLeft );
+	} else if (font == "tinyHandwritten") {
+		tinyHandwritingFont->drawString( sBuf, textPos, alignLeft );
+	} else if (font == "tinyMain") {
+		tinyMainFont->drawString( sBuf, textPos, alignLeft );
+	}
+}
+
+void minitech::drawTileRect( int x, int y, string color, bool flashing ) {
+	doublePair startPos = { (double)x, (double)y };
+	startPos.x *= CELL_D;
+	startPos.y *= CELL_D;
+	float maxAlpha = 0.5;
+	float alpha;
+	if (flashing) {
+		alpha = (stepCount % 40) / 40.0;
+		if (alpha > 0.5) alpha = 1 - alpha;
+		alpha *= maxAlpha;
+	} else {
+		alpha = maxAlpha;
+	}
+	if (color == "red") setDrawColor( 1, 0, 0, alpha );
+	if (color == "green") setDrawColor( 0, 1, 0, alpha );
+	if (color == "blue") setDrawColor( 0, 0, 1, alpha );
+	drawRect( startPos, CELL_D/2, CELL_D/2 );
+}
+
+
+
+
+vector<TransRecord*> minitech::sortUsesTrans(vector<TransRecord*> unsortedTrans) {
+	
+	vector<bool> boolCloseVect = getObjIsCloseVector();
+	vector<float> distScore(unsortedTrans.size(), 0);
+	
+	for ( int i=0; i<unsortedTrans.size(); i++ ) {
+		TransRecord *trans = unsortedTrans[i];
+		
+		int idA = trans->actor;
+		int idB = trans->target;
+		int idC = trans->newActor;
+		int idD = trans->newTarget;
+		int holdingID = getDummyParent(ourLiveObject->holdingID);
+		
+		GridPos currentPos = {currentX, currentY};
+		
+		float punishmentScore = 16.0;
+		
+		if (ourLiveObject->holdingID != idA) {
+			if (idA <= 0) {
+				distScore[i] += punishmentScore;
+			} else if ( boolCloseVect[idA] ) {
+				GridPos pos = getClosestTile(currentPos, idA);
+				float dist = sqrt(pow(currentX - pos.x, 2) + pow(currentY - pos.y, 2));
+				distScore[i] += dist;
+			} else {
+				distScore[i] += 9999;
+			}
+		}
+		if (ourLiveObject->holdingID != idB) {
+			if (idB <= 0) {
+				distScore[i] += punishmentScore;
+			} else if ( boolCloseVect[idB] ) {
+				GridPos pos = getClosestTile(currentPos, idB);
+				float dist = sqrt(pow(currentX - pos.x, 2) + pow(currentY - pos.y, 2));
+				distScore[i] += dist;
+			} else {
+				distScore[i] += 9999;
+			}
+		}
+		if ( idA == idB ) {
+			distScore[i] += punishmentScore; //two stackable items stacked together
+		}
+	}
+	
+	vector<std::size_t> index(unsortedTrans.size());
+	iota(index.begin(), index.end(), 0);
+	sort(index.begin(), index.end(), [&](size_t a, size_t b) { return distScore[a] < distScore[b]; });
+	
+	vector<TransRecord*> temp(unsortedTrans.size());
+	for ( int i=0; i<unsortedTrans.size(); i++ ) {
+		temp[i] = unsortedTrans[index[i]];
+	}
+	return temp;
+}
+
+vector<TransRecord*> minitech::sortProdTrans(vector<TransRecord*> unsortedTrans) {
+	
+	vector<bool> boolCloseVect = getObjIsCloseVector();
+	vector<float> distScore(unsortedTrans.size(), 0);
+	
+	for ( int i=0; i<unsortedTrans.size(); i++ ) {
+		TransRecord *trans = unsortedTrans[i];
+		
+		int idA = trans->actor;
+		int idB = trans->target;
+		int idC = trans->newActor;
+		int idD = trans->newTarget;
+		int holdingID = getDummyParent(ourLiveObject->holdingID);
+		
+		GridPos currentPos = {currentX, currentY};
+		
+		float punishmentScore = 32.0;
+		
+		if (ourLiveObject->holdingID != idA) {
+			if (idA <= 0) {
+				
+			} else if ( boolCloseVect[idA] ) {
+				GridPos pos = getClosestTile(currentPos, idA);
+				float dist = sqrt(pow(currentX - pos.x, 2) + pow(currentY - pos.y, 2));
+				distScore[i] += dist;
+			} else {
+				distScore[i] += punishmentScore;
+			}
+		}
+		if (ourLiveObject->holdingID != idB) {
+			if (idB <= 0) {
+				
+			} else if ( boolCloseVect[idB] ) {
+				GridPos pos = getClosestTile(currentPos, idB);
+				float dist = sqrt(pow(currentX - pos.x, 2) + pow(currentY - pos.y, 2));
+				distScore[i] += dist;
+			} else {
+				distScore[i] += punishmentScore;
+			}
+		}
+		if ( idB == -1 ) distScore[i] += 9999; //item + Bare Ground
+		if ( idA > 0 && idB > 0  ) distScore[i] -= 9999; //actual crafting instead of empty hand use
+		if ( idC <= 0  ) distScore[i] -= 9999; //actualy crafting comsuming actor
+		
+	}
+	
+	vector<std::size_t> index(unsortedTrans.size());
+	iota(index.begin(), index.end(), 0);
+	sort(index.begin(), index.end(), [&](size_t a, size_t b) { return distScore[a] < distScore[b]; });
+	
+	vector<TransRecord*> temp(unsortedTrans.size());
+	for ( int i=0; i<unsortedTrans.size(); i++ ) {
+		temp[i] = unsortedTrans[index[i]];
+	}
+	return temp;
+}
+
+void minitech::updateDrawTwoTech() {
+	
+	int defaultNumOfLines = 5;
+	float iconSize = 76.0/2 *guiScale;
+	float paddingX = 12.0 *guiScale;
+	float paddingY = 12.0 *guiScale;
+	float lineSpacing = 16.0 *guiScale; //spacing between lines of transition
+	float lineHeight = 24.0 *guiScale; //line height of plus and equal sign, handwriting height = 24
+	
+	float separatorHeight = 12.0 *guiScale; //space between header rect and main rect
+	float centerXSeparation = 32.0 *guiScale; //space between how-to buttons and item icon in header
+	float tinyLineHeight = 12.0 *guiScale; //line height of how-to buttons, tinyHandwriting height = 12
+	
+	float contentOffsetY = iconSize/4; //for extra tall objects
+	float iconCaptionYOffset = - iconSize/2;
+	float buttonHeight = iconSize;
+	
+	doublePair screenPos = livingLifePage->minitechGetLastScreenViewCenter();
+	// drawStr(to_string(guiScale), screenPos, "tinyHandwritten", true, true);
+	
+	float recWidth;
+	float recHeight;
+	
+	doublePair posLT = livingLifePage->minitechGetLastScreenViewCenter();
+	posLT.x = posLT.x + viewWidth/2;
+	posLT.y = posLT.y - viewHeight/2;
+	
+	if (minitechMinimized) {
+		
+		recWidth = paddingX + 7*iconSize + paddingX;
+		recHeight = paddingY/2 + lineHeight/2 + paddingY/2;
+		posLT.y = posLT.y + recHeight + (60); //panel height = 60
+		posLT.x = posLT.x - recWidth;
+		doublePair posCenter = {posLT.x + recWidth / 2, posLT.y - recHeight / 2};
+		doublePair posBR = {posLT.x + recWidth, posLT.y - recHeight};
+		setDrawColor( 0, 0, 0, 0.8 );
+		drawRect( posCenter, recWidth/2, recHeight/2);
+		
+		drawStr("[+] CRAFTING GUIDE", posCenter, "tinyHandwritten", false);
+		mouseListener* maxAListener = getMouseListenerByArea(
+			&twotechMouseListeners, sub(posLT, screenPos), sub(posBR, screenPos));
+		if (maxAListener->mouseHover) {
+			setDrawColor( 1, 1, 1, 0.3 );
+			drawRect( posCenter, recWidth/2, recHeight/2);
+		}
+		if (maxAListener->mouseClick) {
+			minitechMinimized = false;
+			maxAListener->mouseClick = false;
+		}
+		return;
+		
+	}
+	
+	int transSize = currentHintTrans.size();
+		
+	if (transSize == 0) {
+		
+		recWidth = paddingX + 7*iconSize + paddingX;
+		recHeight = paddingY + 1*iconSize + paddingY;
+		posLT.y = posLT.y + recHeight + (60); //panel height = 60
+		posLT.x = posLT.x - recWidth;
+		doublePair posCenter = {posLT.x + recWidth / 2, posLT.y - recHeight / 2};
+		setDrawColor( 0, 0, 0, 0.8 );
+		drawRect( posCenter, recWidth/2, recHeight/2);
+		drawStr("NO RECIPES FOUND :)", posCenter, "tinyHandwritten", false);
+		
+	} else {
+		
+		if (currentTwoTechPage < 0) currentTwoTechPage = 0;
+		int maxPage = int( ceil( float(transSize) / float(defaultNumOfLines) ) );
+		if ( currentTwoTechPage >= maxPage ) currentTwoTechPage = maxPage - 1;
+		bool showNextPageButton = transSize > (currentTwoTechPage+1)*defaultNumOfLines;
+		bool showPreviousPageButton = currentTwoTechPage > 0;
+		
+		int startIndex = currentTwoTechPage*defaultNumOfLines;
+		int endIndex = min(transSize, (currentTwoTechPage+1)*defaultNumOfLines);
+		vector<TransRecord*> transToShow(currentHintTrans.begin() + startIndex, currentHintTrans.begin() + endIndex);
+		
+		int numOfLines = endIndex - startIndex;
+		
+		if (!showPreviousPageButton && !showNextPageButton) buttonHeight = 0;
+		
+		recWidth = paddingX + 7*iconSize + paddingX;
+		recHeight = paddingY + (numOfLines-1)*lineSpacing + numOfLines*iconSize + buttonHeight + paddingY;
+		
+		posLT.y = posLT.y + recHeight + (60); //panel height = 60
+		posLT.x = posLT.x - recWidth;
+		
+		doublePair posCenter = {posLT.x + recWidth / 2, posLT.y - recHeight / 2};
+		setDrawColor( 0, 0, 0, 0.8 );
+		drawRect( posCenter, recWidth/2, recHeight/2);
+		
+		doublePair posLineLCen = {
+			posLT.x + paddingX, 
+			posLT.y - paddingY - contentOffsetY - iconSize/2
+			};	
+		
+		int currHintObjId = 0;
+		for (int i=0; i<numOfLines; i++) {
+			if (i>0) posLineLCen.y -= iconSize+lineSpacing;
+			
+			TransRecord* trans = transToShow[i];
+			
+			printf("DEBUG: %d + %d = %d + %d\n", trans->actor, trans->target, trans->newActor, trans->newTarget);
+			printf("DEBUG: %d\n", trans->autoDecaySeconds);
+			
+
+			doublePair posLineTL = {
+				posLineLCen.x - paddingX,
+				posLineLCen.y + iconSize/2
+			};
+			doublePair posLineBR = {
+				posLineTL.x + recWidth,
+				posLineTL.y - iconSize
+			};
+
+			mouseListener* lineListener = getMouseListenerByArea(
+				&twotechMouseListeners, sub(posLineTL, screenPos), sub(posLineBR, screenPos));
+			if (lineListener->mouseHover) {
+				doublePair posLineCen = {posCenter.x, posLineLCen.y};
+				setDrawColor( 1, 1, 1, 0.3 );
+				drawRect(posLineCen, recWidth/2, iconSize/2);
+				
+				int holdingID = ourLiveObject->holdingID;
+				holdingID = getDummyParent(holdingID);
+				if (trans->actor == trans->target) {
+					currHintObjId = trans->actor;
+				} else if (trans->actor > 0 && trans->actor != holdingID) {
+					currHintObjId = trans->actor;
+				} else if (trans->target > 0 && trans->target != holdingID) {
+					currHintObjId = trans->target;
+				} else {
+					currHintObjId = 0;
+				}
+			}
+			
+			
+			doublePair iconLT;
+			doublePair iconBR;
+			
+			doublePair pos = posLineLCen;
+			
+			pos.x += iconSize/2;
+			if (trans->actor == -1 && trans->autoDecaySeconds != 0) {
+				if ( trans->autoDecaySeconds < 0 ) {
+					drawObj(pos, trans->actor, "WAIT", to_string(- trans->autoDecaySeconds) + " HR");
+				} else {
+					int decayTime = trans->autoDecaySeconds;
+					if (decayTime >= 60) {
+						decayTime = int(round(decayTime / 60.0));
+						drawObj(pos, trans->actor, "WAIT", to_string(decayTime) + " MIN");
+					} else {
+						drawObj(pos, trans->actor, "WAIT", to_string(decayTime) + " SEC");
+					}
+				}
+			} else {
+				drawObj(pos, trans->actor);
+			}
+			iconLT = {pos.x - iconSize/2, pos.y + iconSize/2};
+			iconBR = {pos.x + iconSize/2, pos.y - iconSize/2};		
+			mouseListener* iconAListener = getMouseListenerByArea(
+				&twotechMouseListeners, sub(iconLT, screenPos), sub(iconBR, screenPos));
+			if (iconAListener->mouseHover && trans->actor > 0) {
+				doublePair captionPos = {pos.x, pos.y + iconCaptionYOffset};
+				string objDesc(livingLifePage->minitechGetDisplayObjectDescription(trans->actor));
+				drawStr(objDesc, captionPos, "tinyHandwritten", true, true);
+			}
+			if (iconAListener->mouseClick && trans->actor > 0) {
+				currentHintObjId = trans->actor;
+			}
+			
+			pos.x += iconSize;
+			drawStr("+", pos, "handwritten", false);
+			
+			pos.x += iconSize;
+			if (trans->target == -1) {
+				drawObj(pos, trans->target, "EMPTY", "GROUND");
+			} else {
+				drawObj(pos, trans->target);
+			}
+			iconLT = {pos.x - iconSize/2, pos.y + iconSize/2};
+			iconBR = {pos.x + iconSize/2, pos.y - iconSize/2};		
+			mouseListener* iconBListener = getMouseListenerByArea(
+				&twotechMouseListeners, sub(iconLT, screenPos), sub(iconBR, screenPos));
+			if (iconBListener->mouseHover && trans->target > 0) {
+				doublePair captionPos = {pos.x, pos.y + iconCaptionYOffset};
+				string objDesc(livingLifePage->minitechGetDisplayObjectDescription(trans->target));
+				drawStr(objDesc, captionPos, "tinyHandwritten", true, true);
+			}
+			if (iconBListener->mouseClick && trans->target > 0) {
+				currentHintObjId = trans->target;
+			}
+			
+			pos.x += iconSize;
+			drawStr("=", pos, "handwritten", false);
+			
+			pos.x += iconSize;
+			if (trans->actor > 0 && trans->target > 0 && trans->newActor == 0) {
+				drawObj(pos, trans->newActor);
+			} else if (trans->newActor == 0) {
+				drawObj(pos, trans->newActor, "EMPTY", "GROUND");
+			} else {
+				drawObj(pos, trans->newActor);
+			}
+			iconLT = {pos.x - iconSize/2, pos.y + iconSize/2};
+			iconBR = {pos.x + iconSize/2, pos.y - iconSize/2};		
+			mouseListener* iconCListener = getMouseListenerByArea(
+				&twotechMouseListeners, sub(iconLT, screenPos), sub(iconBR, screenPos));
+			if (iconCListener->mouseHover && trans->newActor > 0) {
+				doublePair captionPos = {pos.x, pos.y + iconCaptionYOffset};
+				string objDesc(livingLifePage->minitechGetDisplayObjectDescription(trans->newActor));
+				drawStr(objDesc, captionPos, "tinyHandwritten", true, true);
+			}
+			if (iconCListener->mouseClick && trans->newActor > 0) {
+				currentHintObjId = trans->newActor;
+			}
+			
+			pos.x += iconSize;
+			drawStr("+", pos, "handwritten", false);
+			
+			pos.x += iconSize;
+			drawObj(pos, trans->newTarget);
+			iconLT = {pos.x - iconSize/2, pos.y + iconSize/2};
+			iconBR = {pos.x + iconSize/2, pos.y - iconSize/2};		
+			mouseListener* iconDListener = getMouseListenerByArea(
+				&twotechMouseListeners, sub(iconLT, screenPos), sub(iconBR, screenPos));
+			if (iconDListener->mouseHover && trans->newTarget > 0) {
+				doublePair captionPos = {pos.x, pos.y + iconCaptionYOffset};
+				string objDesc(livingLifePage->minitechGetDisplayObjectDescription(trans->newTarget));
+				drawStr(objDesc, captionPos, "tinyHandwritten", true, true);
+			}
+			if (iconDListener->mouseClick && trans->newTarget > 0) {
+				currentHintObjId = trans->newTarget;
+			}
+		}
+		
+		if (currHintObjId > 0) {
+			GridPos currentPos = {currentX, currentY};
+			GridPos closestHintObjPos = getClosestTile(currentPos, currHintObjId);
+			if ( !(closestHintObjPos.x == 9999 && closestHintObjPos.y == 9999) ) {
+				drawTileRect(closestHintObjPos.x, closestHintObjPos.y, "blue", true);
+			}
+		}
+		
+		posLineLCen.y -= buttonHeight; 
+		doublePair pos = posLineLCen;
+		pos.x += iconSize/2;
+		if (showPreviousPageButton) {
+			drawStr("<", pos, "main", false);
+			doublePair prevPageButtonTLPos = {pos.x - iconSize/2, pos.y + iconSize/2};
+			doublePair prevPageButtonBRPos = {pos.x + iconSize/2, pos.y - iconSize/2};
+			
+			prevListener = getMouseListenerByArea(
+				&twotechMouseListeners, 
+				sub(prevPageButtonTLPos, screenPos), 
+				sub(prevPageButtonBRPos, screenPos));
+			if (prevListener->mouseHover) {
+				setDrawColor( 1, 1, 1, 0.3 );
+				drawRect(pos, iconSize/2, iconSize/2);
+			}
+		} else {
+			prevListener = NULL;
+		}
+		
+		pos.x += iconSize*6;
+		if (showNextPageButton) {
+			drawStr(">", pos, "main", false);
+			doublePair nextPageButtonTLPos = {pos.x - iconSize/2, pos.y + iconSize/2};
+			doublePair nextPageButtonBRPos = {pos.x + iconSize/2, pos.y - iconSize/2};
+			
+			nextListener = getMouseListenerByArea(
+				&twotechMouseListeners, 
+				sub(nextPageButtonTLPos, screenPos), 
+				sub(nextPageButtonBRPos, screenPos));
+			if (nextListener->mouseHover) {
+				setDrawColor( 1, 1, 1, 0.3 );
+				drawRect(pos, iconSize/2, iconSize/2);
+			}
+		} else {
+			nextListener = NULL;
+		}
+		
+		if (showPreviousPageButton || showNextPageButton) {
+			pos.x -= iconSize*3;
+			string pageInd = to_string(currentTwoTechPage + 1) + "/" + to_string(maxPage);
+			drawStr(pageInd, pos, "tinyMain", false);
+		}
+	}
+
+
+	float headerWidth = recWidth;
+	float headerHeight = (paddingY + iconSize + paddingY);
+
+	doublePair headerLT = {posLT.x, posLT.y + separatorHeight + headerHeight};
+	doublePair headerLCen = {headerLT.x + paddingX, headerLT.y - iconSize/2};
+	doublePair headerCen = {headerLT.x + headerWidth / 2, headerLT.y - headerHeight / 2};
+
+	setDrawColor( 0, 0, 0, 0.8 );
+	drawRect( headerCen, headerWidth/2, headerHeight/2);
+	
+
+	string useStr = "HOW DO I USE:";
+	string makeStr = "HOW DO I MAKE:";
+	float textWidth = tinyHandwritingFont->measureString( makeStr.c_str() );
+	float textXOffset = -iconSize/2 - centerXSeparation/2;
+	doublePair textCen = {headerCen.x + textXOffset, headerCen.y};
+	doublePair firstLine = {textCen.x, textCen.y - tinyLineHeight};
+	doublePair secondLine = {textCen.x, textCen.y + tinyLineHeight};
+	doublePair firstLineLT = {firstLine.x - textWidth/2 - paddingX/2, firstLine.y + tinyLineHeight/2 + paddingY/2};
+	doublePair firstLineBR = {firstLine.x + textWidth/2 + paddingX/2, firstLine.y - tinyLineHeight/2 - paddingY/2};
+	doublePair secondLineLT = {secondLine.x - textWidth/2 - paddingX/2, secondLine.y + tinyLineHeight/2 + paddingY/2};
+	doublePair secondLineBR = {secondLine.x + textWidth/2 + paddingX/2, secondLine.y - tinyLineHeight/2 - paddingY/2};
+
+	setDrawColor( 1, 1, 1, 0.3 );
+	if (useOrMake == 0) {
+		drawRect( firstLine, textWidth/2 + paddingX/2, tinyLineHeight/2 + paddingY/2);
+	} else if (useOrMake == 1) {
+		drawRect( secondLine, textWidth/2 + paddingX/2, tinyLineHeight/2 + paddingY/2);
+	}
+	drawStr(useStr, firstLine, "tinyHandwritten", false);
+	drawStr(makeStr, secondLine, "tinyHandwritten", false);
+
+	mouseListener* useListener = getMouseListenerByArea(
+		&twotechMouseListeners, 
+		sub(firstLineLT, screenPos), 
+		sub(firstLineBR, screenPos));
+	if (useListener->mouseClick) useOrMake = 0;
+	mouseListener* makeListener = getMouseListenerByArea(
+		&twotechMouseListeners, 
+		sub(secondLineLT, screenPos), 
+		sub(secondLineBR, screenPos));
+	if (makeListener->mouseClick) useOrMake = 1;
+
+
+	float iconXOffset = textWidth/2 + centerXSeparation/2;
+	doublePair iconCen = {headerCen.x + iconXOffset, headerCen.y - contentOffsetY};
+	drawObj(iconCen, currentHintObjId);
+
+	doublePair iconTL = {iconCen.x - iconSize/2, iconCen.y + iconSize/2};
+	doublePair iconBR = {iconCen.x + iconSize/2, iconCen.y - iconSize/2};
+	mouseListener* headerIconListener = getMouseListenerByArea(
+		&twotechMouseListeners, 
+		sub(iconTL, screenPos), 
+		sub(iconBR, screenPos));
+	if (headerIconListener->mouseHover) {
+		doublePair captionPos = {iconCen.x, iconCen.y + iconCaptionYOffset};
+		string objDesc(livingLifePage->minitechGetDisplayObjectDescription(currentHintObjId));
+		drawStr(objDesc, captionPos, "tinyHandwritten", true, true);
+	}
+
+
+	doublePair headerRT = {headerLT.x + recWidth, headerLT.y};
+	doublePair minRT = {headerRT.x - iconSize/8, headerRT.y - iconSize/8};
+	doublePair minCen = {minRT.x - iconSize/4, minRT.y - iconSize/4};
+	doublePair minLT = {minRT.x - iconSize/2, minRT.y};
+	doublePair minBR = {minRT.x, minRT.y - iconSize/2};
+	drawStr("[-]", minCen, "tinyHandwritten", false);
+	mouseListener* minListener = getMouseListenerByArea(
+		&twotechMouseListeners, 
+		sub(minLT, screenPos), 
+		sub(minBR, screenPos));
+	if (minListener->mouseHover) {
+		setDrawColor( 1, 1, 1, 0.3 );
+		drawRect(minCen, iconSize/4, iconSize/4);
+	}
+	if (minListener->mouseClick) {
+		minitechMinimized = true;
+		minListener->mouseClick = false;
+	}
+}
+
+
+
+void minitech::livingLifeDraw(float mX, float mY) {
+	
+	doublePair screenPos = livingLifePage->minitechGetLastScreenViewCenter();
+	doublePair mousePos = {mX, mY};
+	doublePair mousePosScreenAdj = sub(mousePos, screenPos);
+	
+	for ( int i=twotechMouseListeners.size() - 1; i>=0; i-- ) {
+		mouseListener* listener = twotechMouseListeners[i];
+		if ( posWithinArea(mousePosScreenAdj, listener->posTL, listener->posBR) ) {
+			listener->mouseHover = true;
+			continue;
+		}
+		listener->mouseHover = false;
+		
+		if ( !listener->mouseHover && !listener->mouseClick ) {
+			twotechMouseListeners.erase( twotechMouseListeners.begin() + i );
+		}
+	}
+	
+	if ( prevListener != NULL ) {
+		if ( !prevListener->mouseHover && !prevListener->mouseClick ) {
+			prevListener = NULL;
+		}
+	}
+	if ( nextListener != NULL ) {
+		if ( !nextListener->mouseHover && !nextListener->mouseClick ) {
+			nextListener = NULL;
+		}
+	}
+	
+	
+		
+	ObjectRecord* currentHintObj = getObject(currentHintObjId);
+	if (currentHintObj != NULL) {
+		if (currentHintObj->isUseDummy) currentHintObjId = currentHintObj->useDummyParent;
+	}
+	
+	if ( lastHintObjId == 0 && currentHintObjId != 0 ) minitechMinimized = false;
+	
+	if ( (lastHintObjId != currentHintObjId || lastUseOrMake != useOrMake) && !minitechMinimized ) {
+		lastHintObjId = currentHintObjId;
+		lastUseOrMake = useOrMake;
+		currentTwoTechPage = 0;
+		
+		for (auto p: twotechMouseListeners) {
+			delete(p);
+		}
+		twotechMouseListeners.clear();
+		twotechMouseListeners.shrink_to_fit();
+		
+
+		vector<TransRecord*> unsortedTrans;
+		
+		if (useOrMake == 0) {
+			unsortedTrans = getUsesTrans(currentHintObjId);
+		} else if (useOrMake == 1) {
+			unsortedTrans = getProdTrans(currentHintObjId);
+		}
+		
+		// There could be duplicated transitions...
+		sort( unsortedTrans.begin(), unsortedTrans.end() );
+		unsortedTrans.erase( 
+			unique( unsortedTrans.begin(), unsortedTrans.end() ), 
+			unsortedTrans.end() 
+			);
+			
+		if (useOrMake == 0) {
+			currentHintTrans = sortUsesTrans(unsortedTrans);
+		} else if (useOrMake == 1) {
+			currentHintTrans = sortProdTrans(unsortedTrans);
+		}
+
+	}
+	
+	updateDrawTwoTech();
+
+}
+
+void minitech::livingLifeStep() {
+	ourLiveObject = livingLifePage->getOurLiveObject();
+	if (!ourLiveObject) return;
+	
+	stepCount++;
+	if (stepCount > 10000) stepCount = 0;
+	
+	currentX = round(ourLiveObject->currentPos.x);
+	currentY = round(ourLiveObject->currentPos.y);
+	
+
+}
+
+bool minitech::livingLifeKeyDown(unsigned char inASCII) {	
+	
+	bool commandKey = isCommandKeyDown();
+	bool shiftKey = isShiftKeyDown();
+
+
+	
+	if (!commandKey && !shiftKey && inASCII == 9) {
+		currentTwoTechPage += 1;
+	}
+	
+	if (!commandKey && shiftKey && inASCII == 9) {
+		currentTwoTechPage -= 1;
+	}
+	
+	// if ( inASCII == 'p' ) {
+		// guiScale += 0.3;
+	// }
+	// if ( inASCII == 'l' ) {
+		// guiScale -= 0.3;
+	// }
+	// if ( inASCII == 'p' || inASCII == 'l' ) {
+		// delete minitech::handwritingFont;
+		// delete minitech::mainFont;
+		// delete minitech::tinyHandwritingFont;
+		// delete minitech::tinyMainFont;
+		// minitech::handwritingFont = new Font( "font_handwriting_32_32.tga", 3, 6, false, 16*guiScale );
+		// minitech::handwritingFont->setMinimumPositionPrecision( 1 );
+		// minitech::mainFont = new Font( getFontTGAFileName(), 6, 16, false, 16*guiScale );
+		// minitech::mainFont->setMinimumPositionPrecision( 1 );	
+		// minitech::tinyHandwritingFont = new Font( "font_handwriting_32_32.tga", 3, 6, false, 16/2*guiScale );
+		// minitech::tinyHandwritingFont->setMinimumPositionPrecision( 1 );
+		// minitech::tinyMainFont = new Font( getFontTGAFileName(), 6, 16, false, 16/2*guiScale );
+		// minitech::tinyMainFont->setMinimumPositionPrecision( 1 );
+	// }
+	
+	return false;
+}
+
+bool minitech::livingLifePageMouseDown( float mX, float mY ) {
+	
+	doublePair screenPos = livingLifePage->minitechGetLastScreenViewCenter();
+	doublePair mousePos = {mX, mY};
+	doublePair mousePosScreenAdj = sub(mousePos, screenPos);
+	
+	bool clickCaught = false;
+	for ( int i=0; i<twotechMouseListeners.size(); i++ ) {
+		mouseListener* listener = twotechMouseListeners[i];
+		if ( posWithinArea(mousePosScreenAdj, listener->posTL, listener->posBR) ) {
+			listener->mouseClick = true;
+			clickCaught = true;
+			continue;
+		}
+		listener->mouseClick = false;
+	}
+	
+	if (prevListener != NULL) {
+		if (prevListener->mouseClick) {
+			currentTwoTechPage -= 1;
+			prevListener->mouseClick = false;
+		}
+	}
+	if (nextListener != NULL) {
+		if (nextListener->mouseClick) {
+			currentTwoTechPage += 1;
+			nextListener->mouseClick = false;
+		}
+	}
+	
+	return clickCaught;
+}

--- a/gameSource/minitech.cpp
+++ b/gameSource/minitech.cpp
@@ -822,6 +822,7 @@ void minitech::updateDrawTwoTech() {
 			};	
 		
 		int currHintObjId = 0;
+		vector<pair<mouseListener*,int>> iconListenerIds;
 		for (int i=0; i<numOfLines; i++) {
 			if (i>0) posLineLCen.y -= iconSize+lineSpacing;
 			
@@ -886,11 +887,8 @@ void minitech::updateDrawTwoTech() {
 			iconBR = {pos.x + iconSize/2, pos.y - iconSize/2};		
 			mouseListener* iconAListener = getMouseListenerByArea(
 				&twotechMouseListeners, sub(iconLT, screenPos), sub(iconBR, screenPos));
-			if (iconAListener->mouseHover && trans->actor > 0) {
-				doublePair captionPos = {pos.x, pos.y + iconCaptionYOffset};
-				string objDesc(livingLifePage->minitechGetDisplayObjectDescription(trans->actor));
-				drawStr(objDesc, captionPos, "tinyHandwritten", true, true);
-			}
+			pair<mouseListener*,int> iconAListenerId(iconAListener, trans->actor);
+			iconListenerIds.push_back(iconAListenerId);
 			if (iconAListener->mouseClick && trans->actor > 0) {
 				currentHintObjId = trans->actor;
 			}
@@ -908,11 +906,8 @@ void minitech::updateDrawTwoTech() {
 			iconBR = {pos.x + iconSize/2, pos.y - iconSize/2};		
 			mouseListener* iconBListener = getMouseListenerByArea(
 				&twotechMouseListeners, sub(iconLT, screenPos), sub(iconBR, screenPos));
-			if (iconBListener->mouseHover && trans->target > 0) {
-				doublePair captionPos = {pos.x, pos.y + iconCaptionYOffset};
-				string objDesc(livingLifePage->minitechGetDisplayObjectDescription(trans->target));
-				drawStr(objDesc, captionPos, "tinyHandwritten", true, true);
-			}
+			pair<mouseListener*,int> iconBListenerId(iconBListener, trans->target);
+			iconListenerIds.push_back(iconBListenerId);
 			if (iconBListener->mouseClick && trans->target > 0) {
 				currentHintObjId = trans->target;
 			}
@@ -948,11 +943,8 @@ void minitech::updateDrawTwoTech() {
 			iconBR = {pos.x + iconSize/2, pos.y - iconSize/2};		
 			mouseListener* iconCListener = getMouseListenerByArea(
 				&twotechMouseListeners, sub(iconLT, screenPos), sub(iconBR, screenPos));
-			if (iconCListener->mouseHover && trans->newActor > 0) {
-				doublePair captionPos = {pos.x, pos.y + iconCaptionYOffset};
-				string objDesc(livingLifePage->minitechGetDisplayObjectDescription(trans->newActor));
-				drawStr(objDesc, captionPos, "tinyHandwritten", true, true);
-			}
+			pair<mouseListener*,int> iconCListenerId(iconCListener, trans->newActor);
+			iconListenerIds.push_back(iconCListenerId);
 			if (iconCListener->mouseClick && trans->newActor > 0) {
 				currentHintObjId = trans->newActor;
 			}
@@ -970,13 +962,22 @@ void minitech::updateDrawTwoTech() {
 			iconBR = {pos.x + iconSize/2, pos.y - iconSize/2};		
 			mouseListener* iconDListener = getMouseListenerByArea(
 				&twotechMouseListeners, sub(iconLT, screenPos), sub(iconBR, screenPos));
-			if (iconDListener->mouseHover && trans->newTarget > 0) {
-				doublePair captionPos = {pos.x, pos.y + iconCaptionYOffset};
-				string objDesc(livingLifePage->minitechGetDisplayObjectDescription(trans->newTarget));
-				drawStr(objDesc, captionPos, "tinyHandwritten", true, true);
-			}
+			pair<mouseListener*,int> iconDListenerId(iconDListener, trans->newTarget);
+			iconListenerIds.push_back(iconDListenerId);
 			if (iconDListener->mouseClick && trans->newTarget > 0) {
 				currentHintObjId = trans->newTarget;
+			}
+		}
+		
+		for (int i=0; i<iconListenerIds.size(); i++) {
+			mouseListener* listener = iconListenerIds[i].first;
+			int id = iconListenerIds[i].second;
+			doublePair iconLT = add(listener->posTL, screenPos);
+			doublePair iconCen = { iconLT.x + iconSize/2, iconLT.y - iconSize/2 };
+			if (listener->mouseHover && id > 0) {
+				doublePair captionPos = {iconCen.x, iconCen.y + iconCaptionYOffset};
+				string objDesc(livingLifePage->minitechGetDisplayObjectDescription(id));
+				drawStr(objDesc, captionPos, "tinyHandwritten", true, true);
 			}
 		}
 		

--- a/gameSource/minitech.cpp
+++ b/gameSource/minitech.cpp
@@ -792,9 +792,9 @@ void minitech::updateDrawTwoTech() {
 		
 	} else {
 		
-		if (currentTwoTechPage < 0) currentTwoTechPage = 0;
 		int maxPage = int( ceil( float(transSize) / float(defaultNumOfLines) ) );
-		if ( currentTwoTechPage >= maxPage ) currentTwoTechPage = maxPage - 1;
+		if (currentTwoTechPage < 0) currentTwoTechPage = maxPage - 1;
+		if ( currentTwoTechPage >= maxPage ) currentTwoTechPage = 0;
 		bool showNextPageButton = transSize > (currentTwoTechPage+1)*defaultNumOfLines;
 		bool showPreviousPageButton = currentTwoTechPage > 0;
 		

--- a/gameSource/minitech.cpp
+++ b/gameSource/minitech.cpp
@@ -783,8 +783,8 @@ void minitech::updateDrawTwoTech() {
 			
 			TransRecord* trans = transToShow[i];
 			
-			printf("DEBUG: %d + %d = %d + %d\n", trans->actor, trans->target, trans->newActor, trans->newTarget);
-			printf("DEBUG: %d\n", trans->autoDecaySeconds);
+			// printf("DEBUG: %d + %d = %d + %d\n", trans->actor, trans->target, trans->newActor, trans->newTarget);
+			// printf("DEBUG: %d\n", trans->autoDecaySeconds);
 			
 
 			doublePair posLineTL = {

--- a/gameSource/minitech.cpp
+++ b/gameSource/minitech.cpp
@@ -135,7 +135,9 @@ int minitech::getDummyParent(int objId) {
 bool minitech::isCategory(int objId) {
 	if (objId <= 0) return false;
 	CategoryRecord *c = getCategory( objId );
-	return c != NULL;
+	if (c == NULL) return false;
+    if( !c->isPattern && c->objectIDSet.size() > 0 ) return true;
+    return false;
 }
 
 minitech::mouseListener* minitech::getMouseListenerByArea( 

--- a/gameSource/minitech.cpp
+++ b/gameSource/minitech.cpp
@@ -1116,7 +1116,7 @@ void minitech::updateDrawTwoTech() {
 		&twotechMouseListeners, 
 		sub(iconTL, screenPos), 
 		sub(iconBR, screenPos));
-	if (headerIconListener->mouseHover) {
+	if (headerIconListener->mouseHover && currentHintObjId > 0) {
 		doublePair captionPos = {iconCen.x, iconCen.y + iconCaptionYOffset};
 		string objName(livingLifePage->minitechGetDisplayObjectDescription(currentHintObjId));
 		drawStr(objName, captionPos, "tinyHandwritten", true, true);

--- a/gameSource/minitech.cpp
+++ b/gameSource/minitech.cpp
@@ -410,7 +410,8 @@ vector<TransRecord*> minitech::getUsesTrans(int objId) {
 			continue;
 		}
 		
-		if ( isUseDummy(idA) || isUseDummy(idB) ) continue;
+		if ( isUseDummy(idA) && isUseDummy(idC) ) continue;
+		if ( isUseDummy(idB) && isUseDummy(idD) ) continue;
 		if ( isCategory(idA) || isCategory(idB) || isCategory(idC) || isCategory(idD) ) continue;
 		if ( trans->lastUseActor || trans->lastUseTarget ) continue;
 		
@@ -441,7 +442,8 @@ vector<TransRecord*> minitech::getProdTrans(int objId) {
 		int idD = trans->newTarget;
 		
 		if ( idA == objId || idB == objId ) continue;
-		if ( isUseDummy(idA) || isUseDummy(idB) ) continue;
+		if ( isUseDummy(idA) && isUseDummy(idC) ) continue;
+		if ( isUseDummy(idB) && isUseDummy(idD) ) continue;
 		if ( isCategory(idA) || isCategory(idB) || isCategory(idC) || isCategory(idD) ) continue;
 		if ( trans->lastUseActor || trans->lastUseTarget ) continue;
 		

--- a/gameSource/minitech.cpp
+++ b/gameSource/minitech.cpp
@@ -1055,6 +1055,8 @@ void minitech::updateDrawTwoTech() {
 
 void minitech::livingLifeDraw(float mX, float mY) {
 	
+	if (!minitechEnabled) return;
+	
 	doublePair screenPos = livingLifePage->minitechGetLastScreenViewCenter();
 	doublePair mousePos = {mX, mY};
 	doublePair mousePosScreenAdj = sub(mousePos, screenPos);

--- a/gameSource/minitech.cpp
+++ b/gameSource/minitech.cpp
@@ -1,5 +1,5 @@
 
-#include <windows.h>
+
 #include <vector>
 #include <string>
 #include <numeric> //iota

--- a/gameSource/minitech.cpp
+++ b/gameSource/minitech.cpp
@@ -646,7 +646,7 @@ vector<TransRecord*> minitech::sortUsesTrans(vector<TransRecord*> unsortedTrans)
 				float dist = sqrt(pow(currentX - pos.x, 2) + pow(currentY - pos.y, 2));
 				distScore[i] += dist;
 			} else {
-				distScore[i] += 9999;
+				distScore[i] += 9999 + idB; //ranking empty hand trans by id
 			}
 		}
 		if ( idA == idB ) {
@@ -702,7 +702,7 @@ vector<TransRecord*> minitech::sortProdTrans(vector<TransRecord*> unsortedTrans)
 				float dist = sqrt(pow(currentX - pos.x, 2) + pow(currentY - pos.y, 2));
 				distScore[i] += dist;
 			} else {
-				distScore[i] += punishmentScore;
+				distScore[i] += punishmentScore + idB; //ranking empty hand trans by id
 			}
 		}
 		if ( idB == -1 ) distScore[i] += 9999; //item + Bare Ground

--- a/gameSource/minitech.cpp
+++ b/gameSource/minitech.cpp
@@ -13,6 +13,7 @@
 
 #include "minorGems/util/SimpleVector.h"
 #include "minorGems/game/drawUtils.h"
+#include "minorGems/util/stringUtils.h"
 #include "minorGems/game/Font.h"
 // #include "minorGems/util/SettingsManager.h"
 
@@ -976,8 +977,17 @@ void minitech::updateDrawTwoTech() {
 			doublePair iconCen = { iconLT.x + iconSize/2, iconLT.y - iconSize/2 };
 			if (listener->mouseHover && id > 0) {
 				doublePair captionPos = {iconCen.x, iconCen.y + iconCaptionYOffset};
-				string objDesc(livingLifePage->minitechGetDisplayObjectDescription(id));
-				drawStr(objDesc, captionPos, "tinyHandwritten", true, true);
+				string objName(livingLifePage->minitechGetDisplayObjectDescription(id));
+				drawStr(objName, captionPos, "tinyHandwritten", true, true);
+				
+				ObjectRecord* o = getObject(id);
+				string objFullDesc(stringToUpperCase(o->description));
+				int poundPos = objFullDesc.find("#");
+				if (poundPos != -1) {
+					string objDesc(objFullDesc.substr(poundPos + 1));
+					captionPos.y -= tinyLineHeight*2;
+					drawStr(objDesc, captionPos, "tinyHandwritten", true, true);
+				}
 			}
 		}
 		

--- a/gameSource/minitech.cpp
+++ b/gameSource/minitech.cpp
@@ -277,7 +277,7 @@ float minitech::getTransProbability(TransRecord* trans) {
 	int idC = trans->newActor;
 	int idD = trans->newTarget;
 	
-	TransRecord* t = getTrans( idA, idB, false, false );
+	TransRecord* t = getTrans( idA, idB, trans->lastUseActor, trans->lastUseTarget );
 	int origIdC = t->newActor;
 	int origIdD = t->newTarget;
 	

--- a/gameSource/minitech.cpp
+++ b/gameSource/minitech.cpp
@@ -1101,8 +1101,17 @@ void minitech::updateDrawTwoTech() {
 		sub(iconBR, screenPos));
 	if (headerIconListener->mouseHover) {
 		doublePair captionPos = {iconCen.x, iconCen.y + iconCaptionYOffset};
-		string objDesc(livingLifePage->minitechGetDisplayObjectDescription(currentHintObjId));
-		drawStr(objDesc, captionPos, "tinyHandwritten", true, true);
+		string objName(livingLifePage->minitechGetDisplayObjectDescription(currentHintObjId));
+		drawStr(objName, captionPos, "tinyHandwritten", true, true);
+		
+		ObjectRecord* o = getObject(currentHintObjId);
+		string objFullDesc(stringToUpperCase(o->description));
+		int poundPos = objFullDesc.find("#");
+		if (poundPos != -1) {
+			string objDesc(objFullDesc.substr(poundPos + 1));
+			captionPos.y -= tinyLineHeight*2;
+			drawStr(objDesc, captionPos, "tinyHandwritten", true, true);
+		}
 	}
 
 

--- a/gameSource/minitech.cpp
+++ b/gameSource/minitech.cpp
@@ -252,7 +252,11 @@ GridPos minitech::getClosestTile(GridPos src, int objId) {
 	return foundPos;
 }
 
-
+bool minitech::isUseDummy(int objId) {
+	if (objId <= 0) return false;
+	ObjectRecord* o = getObject(objId);
+	return o->isUseDummy;
+}
 
 int minitech::objIdFromXY( int x, int y ) {
 	int mMapOffsetX = livingLifePage->mMapOffsetX;
@@ -345,31 +349,7 @@ vector<TransRecord*> minitech::getUsesTrans(int objId) {
 		int idC = trans->newActor;
 		int idD = trans->newTarget;
 		
-		// if ( idA < 0 || idB < 0 ) continue;
-		
-		bool isUseDummyA = false;
-		bool isUseDummyB = false;
-		bool isUseDummyC = false;
-		bool isUseDummyD = false;
-		
-		if ( idA > 0 ) {
-			ObjectRecord* a = getObject(idA);
-			isUseDummyA = a->isUseDummy;
-		}
-		if ( idB > 0 ) {
-			ObjectRecord* b = getObject(idB);
-			isUseDummyB = b->isUseDummy;
-		}
-		if ( idC > 0 ) {
-			ObjectRecord* c = getObject(idC);
-			isUseDummyC = c->isUseDummy;
-		}
-		if ( idD > 0 ) {
-			ObjectRecord* d = getObject(idD);
-			isUseDummyD = d->isUseDummy;
-		}
-		if ( isUseDummyA || isUseDummyB ) continue;
-		
+		if ( isUseDummy(idA) || isUseDummy(idB) ) continue;
 		if ( isCategory(idA) || isCategory(idB) || isCategory(idC) || isCategory(idD) ) continue;
 		if ( trans->lastUseActor || trans->lastUseTarget ) continue;
 		
@@ -403,30 +383,7 @@ vector<TransRecord*> minitech::getProdTrans(int objId) {
 		int idD = trans->newTarget;
 		
 		if ( idA == objId || idB == objId ) continue;
-		
-		bool isUseDummyA = false;
-		bool isUseDummyB = false;
-		bool isUseDummyC = false;
-		bool isUseDummyD = false;
-		
-		if ( idA > 0 ) {
-			ObjectRecord* a = getObject(idA);
-			isUseDummyA = a->isUseDummy;
-		}
-		if ( idB > 0 ) {
-			ObjectRecord* b = getObject(idB);
-			isUseDummyB = b->isUseDummy;
-		}
-		if ( idC > 0 ) {
-			ObjectRecord* c = getObject(idC);
-			isUseDummyC = c->isUseDummy;
-		}
-		if ( idD > 0 ) {
-			ObjectRecord* d = getObject(idD);
-			isUseDummyD = d->isUseDummy;
-		}
-		if ( isUseDummyA || isUseDummyB ) continue;
-		
+		if ( isUseDummy(idA) || isUseDummy(idB) ) continue;
 		if ( isCategory(idA) || isCategory(idB) || isCategory(idC) || isCategory(idD) ) continue;
 		if ( trans->lastUseActor || trans->lastUseTarget ) continue;
 		

--- a/gameSource/minitech.cpp
+++ b/gameSource/minitech.cpp
@@ -933,6 +933,12 @@ void minitech::updateDrawTwoTech() {
 			pos.x += iconSize;
 			if (trans->actor > 0 && trans->target > 0 && trans->newActor == 0) {
 				drawObj(pos, trans->newActor);
+			} else if (trans->actor == -1 && trans->autoDecaySeconds != 0 && trans->newActor == 0) {
+				if (trans->move !=0) {
+					drawStr("MOVING...", pos, "tinyHandwritten", false);
+				} else {
+					drawObj(pos, trans->newActor, "TURNING", "INTO...");
+				}
 			} else if (trans->newActor == 0) {
 				drawObj(pos, trans->newActor, "EMPTY", "GROUND");
 			} else {
@@ -952,10 +958,14 @@ void minitech::updateDrawTwoTech() {
 			}
 			
 			pos.x += iconSize;
-			drawStr("+", pos, "handwritten", false);
+			if (trans->actor == -1 && trans->autoDecaySeconds != 0 && trans->newActor == 0) {
+				//not drawing the plus sign for pure Changes over time...
+			} else {
+				drawStr("+", pos, "handwritten", false);
+			}
 			
 			pos.x += iconSize;
-			drawObj(pos, trans->newTarget);
+			drawObj(pos, trans->newTarget, "EMPTY", "GROUND");
 			iconLT = {pos.x - iconSize/2, pos.y + iconSize/2};
 			iconBR = {pos.x + iconSize/2, pos.y - iconSize/2};		
 			mouseListener* iconDListener = getMouseListenerByArea(

--- a/gameSource/minitech.cpp
+++ b/gameSource/minitech.cpp
@@ -970,27 +970,6 @@ void minitech::updateDrawTwoTech() {
 			}
 		}
 		
-		for (int i=0; i<iconListenerIds.size(); i++) {
-			mouseListener* listener = iconListenerIds[i].first;
-			int id = iconListenerIds[i].second;
-			doublePair iconLT = add(listener->posTL, screenPos);
-			doublePair iconCen = { iconLT.x + iconSize/2, iconLT.y - iconSize/2 };
-			if (listener->mouseHover && id > 0) {
-				doublePair captionPos = {iconCen.x, iconCen.y + iconCaptionYOffset};
-				string objName(livingLifePage->minitechGetDisplayObjectDescription(id));
-				drawStr(objName, captionPos, "tinyHandwritten", true, true);
-				
-				ObjectRecord* o = getObject(id);
-				string objFullDesc(stringToUpperCase(o->description));
-				int poundPos = objFullDesc.find("#");
-				if (poundPos != -1) {
-					string objDesc(objFullDesc.substr(poundPos + 1));
-					captionPos.y -= tinyLineHeight*2;
-					drawStr(objDesc, captionPos, "tinyHandwritten", true, true);
-				}
-			}
-		}
-		
 		if (currHintObjId > 0) {
 			GridPos currentPos = {currentX, currentY};
 			GridPos closestHintObjPos = getClosestTile(currentPos, currHintObjId);
@@ -1041,6 +1020,27 @@ void minitech::updateDrawTwoTech() {
 			pos.x -= iconSize*3;
 			string pageInd = to_string(currentTwoTechPage + 1) + "/" + to_string(maxPage);
 			drawStr(pageInd, pos, "tinyMain", false);
+		}
+		
+		for (int i=0; i<iconListenerIds.size(); i++) {
+			mouseListener* listener = iconListenerIds[i].first;
+			int id = iconListenerIds[i].second;
+			doublePair iconLT = add(listener->posTL, screenPos);
+			doublePair iconCen = { iconLT.x + iconSize/2, iconLT.y - iconSize/2 };
+			if (listener->mouseHover && id > 0) {
+				doublePair captionPos = {iconCen.x, iconCen.y + iconCaptionYOffset};
+				string objName(livingLifePage->minitechGetDisplayObjectDescription(id));
+				drawStr(objName, captionPos, "tinyHandwritten", true, true);
+				
+				ObjectRecord* o = getObject(id);
+				string objFullDesc(stringToUpperCase(o->description));
+				int poundPos = objFullDesc.find("#");
+				if (poundPos != -1) {
+					string objDesc(objFullDesc.substr(poundPos + 1));
+					captionPos.y -= tinyLineHeight*2;
+					drawStr(objDesc, captionPos, "tinyHandwritten", true, true);
+				}
+			}
 		}
 	}
 

--- a/gameSource/minitech.h
+++ b/gameSource/minitech.h
@@ -62,6 +62,8 @@ public:
 		vector<mouseListener*>* listeners, doublePair posTL, doublePair posBR );
 	static GridPos getClosestTile(GridPos src, int objId);	
 	static bool isUseDummy(int objId);
+	static bool isProbabilitySet(int objId);
+	static float getTransProbability(TransRecord* trans);
 	
 	static int objIdFromXY( int x, int y );
 	static vector<bool> getObjIsCloseVector();

--- a/gameSource/minitech.h
+++ b/gameSource/minitech.h
@@ -64,6 +64,7 @@ public:
 	static bool isUseDummy(int objId);
 	static bool isProbabilitySet(int objId);
 	static float getTransProbability(TransRecord* trans);
+	static unsigned int LevenshteinDistance(const std::string& s1, const std::string& s2);
 	
 	static int objIdFromXY( int x, int y );
 	static vector<bool> getObjIsCloseVector();
@@ -96,6 +97,8 @@ public:
 	static int lastUseOrMake;
 	static int currentHintObjId;
 	static int lastHintObjId;
+	static string hintStr;
+	static string lastHintStr;
 	static vector<mouseListener*> twotechMouseListeners;
 	static mouseListener* prevListener;
 	static mouseListener* nextListener;

--- a/gameSource/minitech.h
+++ b/gameSource/minitech.h
@@ -1,0 +1,109 @@
+#ifndef minitech_H
+#define minitech_H
+
+#include "LivingLifePage.h"
+#include <vector>
+#include <string>
+
+
+using namespace std;
+
+class minitech
+{
+
+public:
+
+	
+	static bool minitechEnabled;
+	static float guiScale;
+	
+	static float viewWidth;
+	static float viewHeight;
+
+	static Font *handwritingFont;
+	static Font *mainFont;	
+	static Font *tinyHandwritingFont;
+	static Font *tinyMainFont;
+
+	typedef struct {
+		doublePair posTL;
+		doublePair posBR;
+		bool mouseHover;
+		bool mouseClick;
+	} mouseListener;
+
+	static void setLivingLifePage(
+		LivingLifePage *inLivingLifePage, 
+		SimpleVector<LiveObject> *inGameObjects, 
+		int inmMapD,
+		int inPathFindingD,
+		SimpleVector<int> *inmMapContainedStacks,
+		SimpleVector<SimpleVector<int>> *inmMapSubContainedStacks
+		);
+	static LivingLifePage *livingLifePage;
+	static LiveObject *ourLiveObject;
+	static SimpleVector<LiveObject> *players;
+	static int mMapD;
+	static int pathFindingD;
+	static int maxObjects;
+	static SimpleVector<int> *mMapContainedStacks;
+	static SimpleVector<SimpleVector<int>> *mMapSubContainedStacks;
+	
+	static bool minitechMinimized;
+	static int stepCount;
+	static float currentX;
+	static float currentY;
+
+	static bool posWithinArea(doublePair pos, doublePair areaTL, doublePair areaBR);
+	static bool posEqual(doublePair pos1, doublePair pos2);
+	static int getDummyParent(int objId);
+	static bool isCategory(int objId);
+	static mouseListener* getMouseListenerByArea(
+		vector<mouseListener*>* listeners, doublePair posTL, doublePair posBR );
+	static GridPos getClosestTile(GridPos src, int objId);	
+	
+	static int objIdFromXY( int x, int y );
+	static vector<bool> getObjIsCloseVector();
+	static vector<TransRecord*> getUsesTrans(int objId);
+	static vector<TransRecord*> getProdTrans(int objId);
+	
+	static void drawPoint(doublePair posCen, string color);
+	static void drawObj(
+		doublePair posCen, 
+		int objId, 
+		string strDescFirstLine = "", 
+		string strDescSecondLine = "");
+	static void drawStr(
+		string str, 
+		doublePair posCen, 
+		string font, 
+		bool withBackground = true, 
+		bool avoidOffScreen = false);
+	static void drawTileRect( int x, int y, string color, bool flashing = false );
+	
+	static void initOnBirth();
+	static void livingLifeStep();
+	static bool livingLifeKeyDown(unsigned char inASCII);
+	static void livingLifeDraw(float mouseX, float mouseY);
+	static bool livingLifePageMouseDown(float mouseX, float mouseY);
+	
+	static vector<TransRecord*> currentHintTrans;
+	static int currentTwoTechPage;
+	static int useOrMake;
+	static int lastUseOrMake;
+	static int currentHintObjId;
+	static int lastHintObjId;
+	static vector<mouseListener*> twotechMouseListeners;
+	static mouseListener* prevListener;
+	static mouseListener* nextListener;
+	static vector<TransRecord*> sortUsesTrans(vector<TransRecord*> unsortedTrans);
+	static vector<TransRecord*> sortProdTrans(vector<TransRecord*> unsortedTrans);
+	static void updateDrawTwoTech();
+
+	
+
+	
+};
+
+
+#endif

--- a/gameSource/minitech.h
+++ b/gameSource/minitech.h
@@ -61,6 +61,7 @@ public:
 	static mouseListener* getMouseListenerByArea(
 		vector<mouseListener*>* listeners, doublePair posTL, doublePair posBR );
 	static GridPos getClosestTile(GridPos src, int objId);	
+	static bool isUseDummy(int objId);
 	
 	static int objIdFromXY( int x, int y );
 	static vector<bool> getObjIsCloseVector();

--- a/gameSource/minitech.h
+++ b/gameSource/minitech.h
@@ -6,8 +6,6 @@
 #include <string>
 
 
-using namespace std;
-
 class minitech
 {
 
@@ -59,7 +57,7 @@ public:
 	static int getDummyParent(int objId);
 	static bool isCategory(int objId);
 	static mouseListener* getMouseListenerByArea(
-		vector<mouseListener*>* listeners, doublePair posTL, doublePair posBR );
+		std::vector<mouseListener*>* listeners, doublePair posTL, doublePair posBR );
 	static GridPos getClosestTile(GridPos src, int objId);	
 	static bool isUseDummy(int objId);
 	static bool isProbabilitySet(int objId);
@@ -67,23 +65,23 @@ public:
 	static unsigned int LevenshteinDistance(const std::string& s1, const std::string& s2);
 	
 	static int objIdFromXY( int x, int y );
-	static vector<bool> getObjIsCloseVector();
-	static vector<TransRecord*> getUsesTrans(int objId);
-	static vector<TransRecord*> getProdTrans(int objId);
+	static std::vector<bool> getObjIsCloseVector();
+	static std::vector<TransRecord*> getUsesTrans(int objId);
+	static std::vector<TransRecord*> getProdTrans(int objId);
 	
-	static void drawPoint(doublePair posCen, string color);
+	static void drawPoint(doublePair posCen, std::string color);
 	static void drawObj(
 		doublePair posCen, 
 		int objId, 
-		string strDescFirstLine = "", 
-		string strDescSecondLine = "");
+		std::string strDescFirstLine = "", 
+		std::string strDescSecondLine = "");
 	static void drawStr(
-		string str, 
+		std::string str, 
 		doublePair posCen, 
-		string font, 
+		std::string font, 
 		bool withBackground = true, 
 		bool avoidOffScreen = false);
-	static void drawTileRect( int x, int y, string color, bool flashing = false );
+	static void drawTileRect( int x, int y, std::string color, bool flashing = false );
 	
 	static void initOnBirth();
 	static void livingLifeStep();
@@ -91,19 +89,19 @@ public:
 	static void livingLifeDraw(float mouseX, float mouseY);
 	static bool livingLifePageMouseDown(float mouseX, float mouseY);
 	
-	static vector<TransRecord*> currentHintTrans;
+	static std::vector<TransRecord*> currentHintTrans;
 	static int currentTwoTechPage;
 	static int useOrMake;
 	static int lastUseOrMake;
 	static int currentHintObjId;
 	static int lastHintObjId;
-	static string hintStr;
-	static string lastHintStr;
-	static vector<mouseListener*> twotechMouseListeners;
+	static std::string hintStr;
+	static std::string lastHintStr;
+	static std::vector<mouseListener*> twotechMouseListeners;
 	static mouseListener* prevListener;
 	static mouseListener* nextListener;
-	static vector<TransRecord*> sortUsesTrans(vector<TransRecord*> unsortedTrans);
-	static vector<TransRecord*> sortProdTrans(vector<TransRecord*> unsortedTrans);
+	static std::vector<TransRecord*> sortUsesTrans(std::vector<TransRecord*> unsortedTrans);
+	static std::vector<TransRecord*> sortProdTrans(std::vector<TransRecord*> unsortedTrans);
 	static void updateDrawTwoTech();
 
 	


### PR DESCRIPTION
Replacing the in-game tab menu, showing Uses and Produces transitions of holding or pointer-hitting item. Transitions with nearby actor or target are prioritized to be displayed higher up on the list. Hover on the transition the actor or target nearby will be highlighted (since the hintarrow is not on THOL yet)