### PR TITLE
Fixed wild objects disappearing

### DIFF
--- a/server/map.cpp
+++ b/server/map.cpp
@@ -1349,6 +1349,7 @@ static int getBaseMap( int inX, int inY, char *outGridPlacement = NULL ) {
 		density = 1;
 		
 	}
+	setXYRandomSeed( 9877 );
     if( getXYRandom( inX, inY ) < density ) {
  
  


### PR DESCRIPTION
The getMapBiomeIndex function a few lines above this fix would set the seed different than the one intended here ( 9877 ) for biome generation. This, together with blockingCache, caused character to rubberband on invisible blocking tiles.