### PR TITLE
Decayed objects also trigger tapout triggers

### DIFF
--- a/server/map.cpp
+++ b/server/map.cpp
@@ -5470,7 +5470,7 @@ int checkDecayObject( int inX, int inY, int inID ) {
                 // no move happened
  
                 // just set change in DB
-                dbPut( inX, inY, 0, newID );
+                setMapObjectRaw( inX, inY, newID );
                 }
            
                


### PR DESCRIPTION
Parallel fix on OHOL: https://github.com/jasonrohrer/OneLife/commit/1cf638bf99037a43f8225cc85ff492cb55e6f0b5