### PR TITLE
Fixing password restoration upon server restart

### DIFF
--- a/gameSource/objectBank.cpp
+++ b/gameSource/objectBank.cpp
@@ -508,28 +508,52 @@ static void setupObjectPasswordStatus( ObjectRecord *inR ) {
         id = strstr( buf, "id:" );
         if( p && x && y && id ) {
             id = id+3;
-            if ( atoi( id ) == inR->id ) {
-                std::cout << "\nRestoring secret word for object with ID:" << id;
-
+			//The saved objId may not be accruate e.g. we assign pw to opened door, but we usually leave the door closed
+			//Therefore we ignore the saved id here, and assign the pw and GridPos to all possible password-protected objects
+			//This should not cause problems unless multiple pw-protected objects are in the same tile,
+			//which would not be possible in the current system anyway.
+			//The duplicated GridPos on the irrelevant objects will be removed when the GridPos is being interacted with 
+			//(either open/close door or password removal)
+			if ( inR->canHaveInGamePassword ) {
+				
                 *(id-4) = '\0';
                 p = p+5;
 				std::string pw(buf);
 				std::size_t pos = pw.find("word:");
 				pw = pw.substr(pos+5);
+				
+                *(p-6) = '\0';
+                y = y+2;
+				int Y = atoi( y );
+				
+                *(y-3) = '\0';
+                x = x+2;
+				int X = atoi( x );
+				
+				//remove duplicated saved passwords for the same GridPos
+				//so only the last row counts
+				for( int i=0; i<inR->IndX.size(); i++ ) {
+					if ( X == inR->IndX.getElementDirect(i) && Y == inR->IndY.getElementDirect(i) ) {
+						inR->IndPass.deleteElement(i);
+						inR->IndX.deleteElement(i);
+						inR->IndY.deleteElement(i);
+						break;
+						}
+					}
+				
+				std::cout << "\nRestoring secret word for object with ID:" << inR->id;
+				
 				char* pwc = new char[48];
 				strcpy (pwc, pw.c_str());
                 inR->IndPass.push_back( pwc );
                 std::cout << ", secret word: " << pwc;
-
-                *(p-6) = '\0';
-                y = y+2;
-                inR->IndY.push_back( atoi( y ) );
-                std::cout << "; coordinates: y:" << y;
-
-                *(y-3) = '\0';
-                x = x+2;
-                inR->IndX.push_back( atoi( x ) );
-                std::cout << "; x:" << x << ".\n";
+				
+                inR->IndY.push_back( Y );
+                std::cout << "; coordinates: y:" << Y;
+				
+                inR->IndX.push_back( X );
+                std::cout << "; x:" << X << ".\n";
+				
                 }
             }
         }

--- a/gameSource/objectBank.cpp
+++ b/gameSource/objectBank.cpp
@@ -513,8 +513,13 @@ static void setupObjectPasswordStatus( ObjectRecord *inR ) {
 
                 *(id-4) = '\0';
                 p = p+5;
-                inR->IndPass.push_back( p );
-                std::cout << ", secret word: " << p;
+				std::string pw(buf);
+				std::size_t pos = pw.find("word:");
+				pw = pw.substr(pos+5);
+				char* pwc = new char[48];
+				strcpy (pwc, pw.c_str());
+                inR->IndPass.push_back( pwc );
+                std::cout << ", secret word: " << pwc;
 
                 *(p-6) = '\0';
                 y = y+2;

--- a/gameSource/objectBank.cpp
+++ b/gameSource/objectBank.cpp
@@ -541,18 +541,18 @@ static void setupObjectPasswordStatus( ObjectRecord *inR ) {
 						}
 					}
 				
-				std::cout << "\nRestoring secret word for object with ID:" << inR->id;
+				// std::cout << "\nRestoring secret word for object with ID:" << inR->id;
 				
 				char* pwc = new char[48];
 				strcpy (pwc, pw.c_str());
                 inR->IndPass.push_back( pwc );
-                std::cout << ", secret word: " << pwc;
+                // std::cout << ", secret word: " << pwc;
 				
                 inR->IndY.push_back( Y );
-                std::cout << "; coordinates: y:" << Y;
+                // std::cout << "; coordinates: y:" << Y;
 				
                 inR->IndX.push_back( X );
-                std::cout << "; x:" << X << ".\n";
+                // std::cout << "; x:" << X << ".\n";
 				
                 }
             }

--- a/server/map.cpp
+++ b/server/map.cpp
@@ -5268,8 +5268,8 @@ int checkDecayObject( int inX, int inY, int inID ) {
                 if( newX != inX || newY != inY ) {
                     // a reall move!
                    
-                    //printf( "Object moving from (%d,%d) to (%d,%d)\n",
-                    //        inX, inY, newX, newY );
+                    printf( "Object moving from (%d,%d) to (%d,%d)\n",
+                           inX, inY, newX, newY );
                    
                     // move object
                    

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -4333,9 +4333,9 @@ static void makePlayerSay( LiveObject *inPlayer, char *inToSay ) {
         if ( passwordInvocationAndSettingAreSeparated ) {
             sayingPassword = isPasswordInvokingSay( inToSay );
             if( sayingPassword != NULL ) {
-                AppLog::infoF( "2HOL DEBUG: Player says password. New password assigned to a player." );
+                // AppLog::infoF( "2HOL DEBUG: Player says password. New password assigned to a player." );
                 inPlayer->saidPassword = stringDuplicate( sayingPassword );
-                AppLog::infoF( "2HOL DEBUG: Player's password is %s", inPlayer->saidPassword );
+                // AppLog::infoF( "2HOL DEBUG: Player's password is %s", inPlayer->saidPassword );
 				//if passwordSilent = true, no need to display anything, as well as make any further checks, just cut it after the assignment is done
 				if( passwordSilent ) { return; }
                 }
@@ -4345,10 +4345,10 @@ static void makePlayerSay( LiveObject *inPlayer, char *inToSay ) {
     
         assigningPassword = isPasswordSettingSay( inToSay );
         if( assigningPassword != NULL ) {
-            AppLog::infoF( "2HOL DEBUG: Player sets new password for future assignment." );
+            // AppLog::infoF( "2HOL DEBUG: Player sets new password for future assignment." );
             inPlayer->assignedPassword = stringDuplicate( assigningPassword );
             if ( !passwordInvocationAndSettingAreSeparated ) { inPlayer->saidPassword = stringDuplicate( assigningPassword ); }
-            AppLog::infoF( "2HOL DEBUG: Password for future assignment password is %s", inPlayer->assignedPassword );
+            // AppLog::infoF( "2HOL DEBUG: Password for future assignment password is %s", inPlayer->assignedPassword );
             //if passwordSilent = true, no need to display anything, as well as make any further checks, just cut it after the assignment is done
             if( passwordSilent ) { return; }
             }
@@ -10157,26 +10157,26 @@ static char isAccessBlocked( LiveObject *inPlayer,
 		//2HOL additions for: password-protected objects
 		//the check to block the transition for the object which password was not guessed correctly
 		if( passwordTransitionsAllowed && targetObj->canHaveInGamePassword ) {
-			AppLog::infoF( "2HOL DEBUG: attempt to interact with an object potentially having password" );
-			AppLog::infoF( "2HOL DEBUG: there are %i protected tiles with object ID %i in the world", targetObj->IndX.size(), targetObj->id );
-			AppLog::infoF( "2HOL DEBUG: interaction location, x: %i", x );
-			AppLog::infoF( "2HOL DEBUG: interaction location, y: %i", y );
+			// AppLog::infoF( "2HOL DEBUG: attempt to interact with an object potentially having password" );
+			// AppLog::infoF( "2HOL DEBUG: there are %i protected tiles with object ID %i in the world", targetObj->IndX.size(), targetObj->id );
+			// AppLog::infoF( "2HOL DEBUG: interaction location, x: %i", x );
+			// AppLog::infoF( "2HOL DEBUG: interaction location, y: %i", y );
 			for( int i=0; i<targetObj->IndX.size(); i++ ) {
 				if ( x == targetObj->IndX.getElementDirect(i) && y == targetObj->IndY.getElementDirect(i) ) {
-					AppLog::infoF( "2HOL DEBUG: protected tile #%i, password: %s", i, targetObj->IndPass.getElementDirect(i) );
+					// AppLog::infoF( "2HOL DEBUG: protected tile #%i, password: %s", i, targetObj->IndPass.getElementDirect(i) );
 					if ( inPlayer->saidPassword == NULL ) {
-							AppLog::infoF( "2HOL DEBUG: player didn't say any password." );
+							// AppLog::infoF( "2HOL DEBUG: player didn't say any password." );
 							blockedByPassword = true;
 					}
 					else {
-						AppLog::infoF( "2HOL DEBUG: player's password: %s", inPlayer->saidPassword );
+						// AppLog::infoF( "2HOL DEBUG: player's password: %s", inPlayer->saidPassword );
 						char *pass = strstr( inPlayer->saidPassword, targetObj->IndPass.getElementDirect(i) );
 						if ( pass ) {
-							AppLog::infoF( "2HOL DEBUG: passwords match." );
+							// AppLog::infoF( "2HOL DEBUG: passwords match." );
 							blockedByPassword = false;
 							}
 						else {
-							AppLog::infoF( "2HOL DEBUG: passwords do not match." );
+							// AppLog::infoF( "2HOL DEBUG: passwords do not match." );
 							blockedByPassword = true;
 							}
 						}
@@ -10185,7 +10185,7 @@ static char isAccessBlocked( LiveObject *inPlayer,
 				}
 			// 2HOL, password-protected objects: or for which the password was not guessed
 			if ( blockedByPassword ) {
-				 AppLog::infoF( "2HOL DEBUG: attempt to interact was blocked: wrong password." );
+				 // AppLog::infoF( "2HOL DEBUG: attempt to interact was blocked: wrong password." );
 				}
 			}
         }
@@ -12002,8 +12002,8 @@ int main() {
             if( message != NULL ) {
                 someClientMessageReceived = true;
                 
-                //AppLog::infoF( "Got client message from %d: %s",
-                //               nextPlayer->id, message );
+                AppLog::infoF( "Got client message from %d: %s",
+                              nextPlayer->id, message );
                 
                 ClientMessage m = parseMessage( nextPlayer, message );
                 
@@ -14043,11 +14043,11 @@ int main() {
                                          getObject( oldHolding )->canGetInGamePassword &&
                                          getObject( r->newTarget )->canHaveInGamePassword ) {                                           
 
-                                            AppLog::infoF( "2HOL DEBUG: retrieving player's password." );
+                                            // AppLog::infoF( "2HOL DEBUG: retrieving player's password." );
                                             char *found = nextPlayer->assignedPassword;
                                             
-                                            if ( found == NULL ) {AppLog::infoF( "    2HOL DEBUG: password returned NULL." );}
-                                            else { if ( found[0] == '\0' ) {AppLog::infoF( "    2HOL DEBUG: password string is empty." );} }
+                                            // if ( found == NULL ) {AppLog::infoF( "    2HOL DEBUG: password returned NULL." );}
+                                            // else { if ( found[0] == '\0' ) {AppLog::infoF( "    2HOL DEBUG: password string is empty." );} }
                                             
                                             if ( ( found != NULL ) && ( found[0] != '\0') ) {
                                                
@@ -14078,12 +14078,12 @@ int main() {
                                                 //erasing player's password after each successful transition
                                                 nextPlayer->assignedPassword = NULL;
                                                 
-                                                                                              AppLog::infoF( "2HOL DEBUG: saved password-protected position, x = %i", getObject( r->newTarget )->IndX.getElementDirect(getObject( r->newTarget )->IndX.size()-1));
-                                                AppLog::infoF( "2HOL DEBUG: saved password-protected position, y = %i", getObject( r->newTarget )->IndY.getElementDirect(getObject( r->newTarget )->IndY.size()-1));
-                                                AppLog::infoF( "2HOL DEBUG: saved password: %s", getObject( r->newTarget )->IndPass.getElementDirect(getObject( r->newTarget )->IndPass.size()-1));
+                                                                                              // AppLog::infoF( "2HOL DEBUG: saved password-protected position, x = %i", getObject( r->newTarget )->IndX.getElementDirect(getObject( r->newTarget )->IndX.size()-1));
+                                                // AppLog::infoF( "2HOL DEBUG: saved password-protected position, y = %i", getObject( r->newTarget )->IndY.getElementDirect(getObject( r->newTarget )->IndY.size()-1));
+                                                // AppLog::infoF( "2HOL DEBUG: saved password: %s", getObject( r->newTarget )->IndPass.getElementDirect(getObject( r->newTarget )->IndPass.size()-1));
                                             }
                                             else {
-                                                AppLog::infoF( "2HOL DEBUG: object has no password to copy.");
+                                                // AppLog::infoF( "2HOL DEBUG: object has no password to copy.");
                                             }
                                             
                                         }
@@ -14110,7 +14110,7 @@ int main() {
 												for( int i=0; i<obj->IndX.size(); i++ ) {
 													if ( m.x == obj->IndX.getElementDirect(i) && m.y == obj->IndY.getElementDirect(i) ) {
 														if (targetObj->id == id) pass = obj->IndPass.getElementDirect(i);
-															AppLog::infoF( "2HOL DEBUG: the password is deleted from the object with ID %i, located at the position (%i,%i).", obj->id, m.x, m.y);
+															// AppLog::infoF( "2HOL DEBUG: the password is deleted from the object with ID %i, located at the position (%i,%i).", obj->id, m.x, m.y);
 														obj->IndPass.deleteElement(i);
 														obj->IndX.deleteElement(i);
 														obj->IndY.deleteElement(i);
@@ -14129,9 +14129,9 @@ int main() {
                                             getObject( r->newTarget )->IndY.push_back( m.y );
                                             getObject( r->newTarget )->IndPass.push_back( pass );
                                                 
-                                            AppLog::infoF( "2HOL DEBUG: updated password-protected position, x = %i", getObject( r->newTarget )->IndX.getElementDirect(getObject( r->newTarget )->IndX.size()-1));
-                                            AppLog::infoF( "2HOL DEBUG: updated password-protected position, y = %i", getObject( r->newTarget )->IndY.getElementDirect(getObject( r->newTarget )->IndY.size()-1));
-                                            AppLog::infoF( "2HOL DEBUG: password: %s", getObject( r->newTarget )->IndPass.getElementDirect(getObject( r->newTarget )->IndPass.size()-1));
+                                            // AppLog::infoF( "2HOL DEBUG: updated password-protected position, x = %i", getObject( r->newTarget )->IndX.getElementDirect(getObject( r->newTarget )->IndX.size()-1));
+                                            // AppLog::infoF( "2HOL DEBUG: updated password-protected position, y = %i", getObject( r->newTarget )->IndY.getElementDirect(getObject( r->newTarget )->IndY.size()-1));
+                                            // AppLog::infoF( "2HOL DEBUG: password: %s", getObject( r->newTarget )->IndPass.getElementDirect(getObject( r->newTarget )->IndPass.size()-1));
                                         }
                                     }
 
@@ -17318,9 +17318,9 @@ int main() {
             
             char *updateListString = updateList.getElementString();
             
-            //AppLog::infoF( "Need to send updates about these %d players: %s",
-            //               playerIndicesToSendUpdatesAbout.size(),
-            //               updateListString );
+            AppLog::infoF( "Need to send updates about these %d players: %s",
+                          playerIndicesToSendUpdatesAbout.size(),
+                          updateListString );
             delete [] updateListString;
             }
         
@@ -17606,9 +17606,9 @@ int main() {
             
             char *updateListString = trueUpdateList.getElementString();
             
-            //AppLog::infoF( "Sending updates about these %d players: %s",
-            //               newUpdatePlayerIDs.size(),
-            //               updateListString );
+            AppLog::infoF( "Sending updates about these %d players: %s",
+                          newUpdatePlayerIDs.size(),
+                          updateListString );
             delete [] updateListString;
             }
         
@@ -19634,10 +19634,10 @@ int main() {
             
             char *playerListString = playerList.getElementString();
 
-            //AppLog::infoF( "%d/%d players were sent part of a %d-line PU: %s",
-            //               playersReceivingPlayerUpdate.size(),
-            //               numLive, newUpdates.size(),
-            //               playerListString );
+            AppLog::infoF( "%d/%d players were sent part of a %d-line PU: %s",
+                          playersReceivingPlayerUpdate.size(),
+                          numLive, newUpdates.size(),
+                          playerListString );
             
             delete [] playerListString;
             }

--- a/server/server.cpp
+++ b/server/server.cpp
@@ -14050,6 +14050,17 @@ int main() {
                                             // else { if ( found[0] == '\0' ) {AppLog::infoF( "    2HOL DEBUG: password string is empty." );} }
                                             
                                             if ( ( found != NULL ) && ( found[0] != '\0') ) {
+												
+												//Clear old passwords before assigning the new one to this tile
+												//These old passwords are from password restoration after server restart, not from players
+												for( int i=0; i<getObject( r->newTarget )->IndX.size(); i++ ) {
+													if ( m.x == getObject( r->newTarget )->IndX.getElementDirect(i) && m.y == getObject( r->newTarget )->IndY.getElementDirect(i) ) {
+														getObject( r->newTarget )->IndPass.deleteElement(i);
+														getObject( r->newTarget )->IndX.deleteElement(i);
+														getObject( r->newTarget )->IndY.deleteElement(i);
+														break;
+													}
+												}
                                                
                                                 getObject( r->newTarget )->IndX.push_back( m.x );
                                                 getObject( r->newTarget )->IndY.push_back( m.y );


### PR DESCRIPTION
Saved ids are ignored, the coords are used instead as discriminators. When the password-protected tile is interacted with, the coords will be removed from all other irrelevant objects. This is the dirty fix to bypass the inaccurate saved objIds.

The ids are inaccurate because the original code assumes a different implementation. (So that id of opened door is saved now, but most people leave closed doors instead)