### PR TITLE
Do not consider worn-only sprites when computing object center

### DIFF
--- a/gameSource/objectBank.cpp
+++ b/gameSource/objectBank.cpp
@@ -5426,6 +5426,11 @@ doublePair getObjectCenterOffset( ObjectRecord *inObject ) {
             // don't consider translucent sprites when computing wideness
             continue;
             }
+
+        if( inObject->spriteInvisibleWhenWorn[i] == 2 ) {
+            // don't consider parts visible only when worn
+            continue;
+            }
         
 
         int w = sprite->visibleW;


### PR DESCRIPTION
https://github.com/jasonrohrer/OneLife/commit/5cfc5aa56467c1e6b9e7997e5d30fc27dea978be