### PR TITLE
Changed network command to /NETWORK

### DIFF
--- a/gameSource/languages/English.txt
+++ b/gameSource/languages/English.txt
@@ -388,7 +388,7 @@ dieCommand "/DIE"
 
 fpsCommand "/FPS"
 
-netCommand "/NET"
+netCommand "/NETWORK"
 
 pingCommand "/PING"
 


### PR DESCRIPTION
To avoid clash when searching for recipe for fishing net

Relevant change in OHOL: https://github.com/jasonrohrer/OneLife/commit/c3912288f77e177dd2107c23606afdb4c1c7b1ae