### PR TITLE
Cont tags are inherited from parent categories to child objects

### DIFF
--- a/server/server.cpp
+++ b/server/server.cpp
@@ -8380,6 +8380,64 @@ static char containmentPermitted( int inContainerID, int inContainedID ) {
     // matching tags for container and object, skip other checks
     if( isContainmentWithMatchedTags( inContainerID, inContainedID ) ) return true;
     
+    // container and object have parent categories which have matching tags, skip other checks
+    
+    ReverseCategoryRecord *containedRecord = getReverseCategory( inContainedID );
+        
+    if( containedRecord != NULL ) {    
+            
+        for( int j=0; j< containedRecord->categoryIDSet.size(); j++ ) {
+                
+            int containedCID = containedRecord->categoryIDSet.getElementDirect( j );
+            
+            CategoryRecord *containedCategory = getCategory( containedCID );
+                
+            if( containedCategory != NULL ) {
+                int containedPID = containedCategory->parentID;
+                
+                if( isContainmentWithMatchedTags( inContainerID, containedPID ) ) return true;
+                
+                }
+            }
+        }
+    
+    ReverseCategoryRecord *containerRecord = getReverseCategory( inContainerID );
+        
+    if( containerRecord != NULL ) {    
+            
+        for( int i=0; i< containerRecord->categoryIDSet.size(); i++ ) {
+                
+            int containerCID = containerRecord->categoryIDSet.getElementDirect( i );
+            
+            CategoryRecord *containerCategory = getCategory( containerCID );
+                
+            if( containerCategory != NULL ) {
+                int containerPID = containerCategory->parentID;
+                
+                if( isContainmentWithMatchedTags( containerPID, inContainedID ) ) return true;
+                
+                ReverseCategoryRecord *containedRecord = getReverseCategory( inContainedID );
+                    
+                if( containedRecord != NULL ) {    
+                        
+                    for( int j=0; j< containedRecord->categoryIDSet.size(); j++ ) {
+                            
+                        int containedCID = containedRecord->categoryIDSet.getElementDirect( j );
+                        
+                        CategoryRecord *containedCategory = getCategory( containedCID );
+                            
+                        if( containedCategory != NULL ) {
+                            int containedPID = containedCategory->parentID;
+                            
+                            if( isContainmentWithMatchedTags( containerPID, containedPID ) ) return true;
+                            
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    
     // object not containable
     if( !isContainable( inContainedID ) ) return false;
     


### PR DESCRIPTION
So that a class of +cont objects and/or containers can be put into one category and simply have the tag on that category object, instead of tagging all those objects individually.