### PR TITLE
Added containment transitions

### DIFF
--- a/gameSource/EditorTransitionPage.cpp
+++ b/gameSource/EditorTransitionPage.cpp
@@ -73,12 +73,18 @@ static ObjectPickable objectPickableAlt;
 static const char *moveButtonNames[NUM_MOVE_BUTTONS] =
 { "None", "Chase", "Flee", "Random", "North", "South", "East", "West", "Find" };
 
+#define NUM_CONTTRANS_MODES 5
+static const char *contTransModeNames[NUM_CONTTRANS_MODES] =
+{ "None", "First", "Last", "Not Swap", "Any" };
+
 
 EditorTransitionPage::EditorTransitionPage()
         : mAutoDecayTimeField( smallFont, 
                                0,  -170, 6,
                                false,
                                "AutoDecay Seconds", "-0123456789", NULL ),
+          mContTransModesButtons( smallFont, -330, -170,
+                            NUM_CONTTRANS_MODES, contTransModeNames, true, 2 ),
           mLastUseActorCheckbox( -330, 75, 2 ),
           mLastUseTargetCheckbox( 130, 75, 2 ),
           mReverseUseActorCheckbox( -330, -75, 2 ),
@@ -123,6 +129,9 @@ EditorTransitionPage::EditorTransitionPage()
 
     addComponent( &mAutoDecayTimeField );
     mAutoDecayTimeField.setVisible( false );
+
+    addComponent( &mContTransModesButtons );
+    mContTransModesButtons.addActionListener( this );
     
     addComponent( &mLastUseActorCheckbox );
     mLastUseActorCheckbox.addActionListener( this );
@@ -215,6 +224,7 @@ EditorTransitionPage::EditorTransitionPage()
     mCurrentTransition.newActor = 0;
     mCurrentTransition.newTarget = 0;
     mCurrentTransition.autoDecaySeconds = 0;
+    mCurrentTransition.contTransFlag = 0;
     mCurrentTransition.lastUseActor = false;
     mCurrentTransition.lastUseTarget = false;
     mCurrentTransition.reverseUseActor = false;
@@ -367,6 +377,8 @@ void EditorTransitionPage::checkIfSaveVisible() {
 
     mDelButton.setVisible( delVis );
     mDelConfirmButton.setVisible( false );
+
+    mContTransModesButtons.setSelectedItem( mCurrentTransition.contTransFlag );
 
     mLastUseActorCheckbox.setToggled( mCurrentTransition.lastUseActor );
     mLastUseTargetCheckbox.setToggled( mCurrentTransition.lastUseTarget );
@@ -698,6 +710,7 @@ void EditorTransitionPage::actionPerformed( GUIComponent *inTarget ) {
                   mCurrentTransition.newTarget,
                   mCurrentTransition.lastUseActor,
                   mCurrentTransition.lastUseTarget,
+                  mContTransModesButtons.getSelectedItem(),
                   mCurrentTransition.reverseUseActor,
                   mCurrentTransition.reverseUseTarget,
                   mCurrentTransition.noUseActor,
@@ -763,7 +776,8 @@ void EditorTransitionPage::actionPerformed( GUIComponent *inTarget ) {
 
         deleteTransFromBank( actor, target, 
                              mLastUseActorCheckbox.getToggled(),
-                             mLastUseTargetCheckbox.getToggled() );
+                             mLastUseTargetCheckbox.getToggled(),
+                             mContTransModesButtons.getSelectedItem() );
                              
         for( int i=0; i<4; i++ ) {
             setObjectByIndex( &mCurrentTransition, i, 0 );
@@ -794,6 +808,23 @@ void EditorTransitionPage::actionPerformed( GUIComponent *inTarget ) {
             }
         
         }
+    else if( inTarget == &mContTransModesButtons ) {
+        mCurrentTransition.contTransFlag = mContTransModesButtons.getSelectedItem();
+        
+        if( mCurrentTransition.contTransFlag > 0 ) {
+            mAutoDecayTimeField.setVisible( false );
+            mAutoDecayTimeField.setText( "" );
+
+            mMovementButtons.setSelectedItem( 0 );
+            mMovementButtons.setVisible( false );
+            
+            mDesiredMoveDistField.setInt( 1 );
+            mDesiredMoveDistField.setVisible( false );    
+            }
+        else {   
+            checkIfSaveVisible();
+            }
+        }
     else if( inTarget == &mLastUseActorCheckbox ) {
         mCurrentTransition.lastUseActor = mLastUseActorCheckbox.getToggled();
         }
@@ -821,6 +852,7 @@ void EditorTransitionPage::actionPerformed( GUIComponent *inTarget ) {
         
         if( mCurrentTransition.move > 0 ) {
             mDesiredMoveDistField.setVisible( true );
+            mContTransModesButtons.setSelectedItem( 0 );
             }
         else {
             mDesiredMoveDistField.setInt( 1 );
@@ -1281,6 +1313,12 @@ void EditorTransitionPage::draw( doublePair inViewCenter,
         }
     
     setDrawColor( 1, 1, 1, 1 );
+    
+    if( mContTransModesButtons.isVisible() ) {
+        doublePair pos = mContTransModesButtons.getPosition();
+        pos.x -= checkboxSep;
+        smallFont->drawString( "Cont Trans", pos, alignRight );
+        }
     
     if( mLastUseActorCheckbox.isVisible() ) {
         doublePair pos = mLastUseActorCheckbox.getPosition();

--- a/gameSource/EditorTransitionPage.h
+++ b/gameSource/EditorTransitionPage.h
@@ -60,7 +60,9 @@ class EditorTransitionPage : public GamePage, public ActionListener {
     protected:
         
         TextField mAutoDecayTimeField;
-
+        
+        RadioButtonSet mContTransModesButtons;
+        
         CheckboxButton mLastUseActorCheckbox;
         CheckboxButton mLastUseTargetCheckbox;
 

--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -13795,6 +13795,10 @@ void LivingLifePage::step() {
                             responsiblePlayerObject = 
                                 getGameObject( responsiblePlayerID );
                             }
+                        if( responsiblePlayerID < -1 ) {
+                            responsiblePlayerObject = 
+                                getGameObject( -responsiblePlayerID );
+                            }
                         
                         if( old > 0 &&
                             newID > 0 &&
@@ -13814,12 +13818,27 @@ void LivingLifePage::step() {
                             }
                         
 
-                        if( old > 0 &&
+                        if( (old > 0 &&
                             old == newID &&
                             mMapContainedStacks[mapI].size() > 
                             oldContainedCount &&
                             responsiblePlayerObject != NULL &&
-                            responsiblePlayerObject->holdingID == 0 ) {
+                            responsiblePlayerObject->holdingID == 0) 
+                            
+                            ||
+                            
+                            // exception case for containment transition
+                            // denoted by responsiblePlayerID being negative of the actual
+                            // newID could have changed in this case
+                            // but we still want the container using sound
+                            (old > 0 &&
+                            mMapContainedStacks[mapI].size() > 
+                            oldContainedCount &&
+                            responsiblePlayerObject != NULL &&
+                            responsiblePlayerID < -1 &&
+                            responsiblePlayerObject->holdingID == 0)
+
+                            ) {
                             
                             // target is changed container and
                             // responsible player's hands now empty

--- a/gameSource/transitionBank.cpp
+++ b/gameSource/transitionBank.cpp
@@ -100,6 +100,7 @@ float initTransBankStep() {
         int target = -2;
         char lastUseActor = false;
         char lastUseTarget = false;
+        int contTransFlag = 0;
         
         if( strstr( txtFileName, "_LA" ) != NULL ) {
             lastUseActor = true;
@@ -111,6 +112,21 @@ float initTransBankStep() {
             // old file name format
             // _L means last use of target
             lastUseTarget = true;
+            }
+            
+        if( strstr( txtFileName, "_CONT" ) != NULL ) {
+            if( strstr( txtFileName, "_CONTF" ) != NULL ) {
+                contTransFlag = 1;
+                }
+            else if( strstr( txtFileName, "_CONTL" ) != NULL ) {
+                contTransFlag = 2;
+                }
+            else if( strstr( txtFileName, "_CONTS" ) != NULL ) {
+                contTransFlag = 3;
+                }
+            else {
+                contTransFlag = 4;
+                }
             }
         
         sscanf( txtFileName, "%d_%d", &actor, &target );
@@ -160,6 +176,7 @@ float initTransBankStep() {
                 r->epochAutoDecay = epochAutoDecay;
                 r->lastUseActor = lastUseActor;
                 r->lastUseTarget = lastUseTarget;
+                r->contTransFlag = contTransFlag;
 
                 r->move = move;
                 r->desiredMoveDist = desiredMoveDist;
@@ -379,7 +396,8 @@ void initTransBankFinish() {
                         
                         TransRecord *oTR = getTrans( oID, tr->target, 
                                                      tr->lastUseActor,
-                                                     tr->lastUseTarget );
+                                                     tr->lastUseTarget,
+                                                     tr->contTransFlag );
                         
                         if( oTR != NULL ) {
                             // skip this abstract trans
@@ -392,7 +410,8 @@ void initTransBankFinish() {
                         
                         TransRecord *oTR = getTrans( tr->actor, oID,
                                                      tr->lastUseActor,
-                                                     tr->lastUseTarget );
+                                                     tr->lastUseTarget,
+                                                     tr->contTransFlag );
                         
                         if( oTR != NULL ) {
                             // skip this abstract trans
@@ -424,6 +443,7 @@ void initTransBankFinish() {
                         addTrans( actor, target, newActor, newTarget,
                                   tr->lastUseActor,
                                   tr->lastUseTarget,
+                                  tr->contTransFlag,
                                   tr->reverseUseActor,
                                   tr->reverseUseTarget,
                                   tr->noUseActor,
@@ -460,6 +480,7 @@ void initTransBankFinish() {
                         addTrans( actor, target, newActor, newTarget,
                                   tr->lastUseActor,
                                   tr->lastUseTarget,
+                                  tr->contTransFlag,
                                   tr->reverseUseActor,
                                   tr->reverseUseTarget,
                                   tr->noUseActor,
@@ -495,6 +516,7 @@ void initTransBankFinish() {
                         addTrans( actor, target, newActor, newTarget,
                                   tr->lastUseActor,
                                   tr->lastUseTarget,
+                                  tr->contTransFlag,
                                   tr->reverseUseActor,
                                   tr->reverseUseTarget,
                                   tr->noUseActor,
@@ -598,7 +620,8 @@ void initTransBankFinish() {
                     TransRecord *existingTrans = getTrans( newTransIDs[0],
                                                            newTransIDs[1],
                                                            tr->lastUseActor,
-                                                           tr->lastUseTarget );
+                                                           tr->lastUseTarget,
+                                                           tr->contTransFlag );
                     if( existingTrans == NULL ) {    
                         // no authored trans exists
 
@@ -608,6 +631,7 @@ void initTransBankFinish() {
                                   newTransIDs[3],
                                   tr->lastUseActor,
                                   tr->lastUseTarget,
+                                  tr->contTransFlag,
                                   tr->reverseUseActor,
                                   tr->reverseUseTarget,
                                   tr->noUseActor,
@@ -758,6 +782,7 @@ void initTransBankFinish() {
                       tr.newActor, tr.newTarget,
                       tr.lastUseActor,
                       tr.lastUseTarget,
+                      tr.contTransFlag,
                       tr.reverseUseActor,
                       tr.reverseUseTarget,
                       tr.noUseActor,
@@ -827,6 +852,7 @@ void initTransBankFinish() {
             TransRecord newTrans = *tr;
             newTrans.lastUseActor = false;
             newTrans.lastUseTarget = false;
+            newTrans.contTransFlag = tr->contTransFlag;
             newTrans.reverseUseActor = false;
             newTrans.reverseUseTarget = false;
             newTrans.noUseActor = false;
@@ -1322,6 +1348,7 @@ void initTransBankFinish() {
             deleteTransFromBank( tr->actor, tr->target,
                                  tr->lastUseActor,
                                  tr->lastUseTarget,
+                                 tr->contTransFlag,
                                  true );
             numRemoved++;
             }
@@ -1335,6 +1362,7 @@ void initTransBankFinish() {
                       newTrans->newTarget,
                       newTrans->lastUseActor,
                       newTrans->lastUseTarget,
+                      newTrans->contTransFlag,
                       newTrans->reverseUseActor,
                       newTrans->reverseUseTarget,
                       newTrans->noUseActor,
@@ -1496,6 +1524,7 @@ void initTransBankFinish() {
                       newTrans->newTarget,
                       newTrans->lastUseActor,
                       newTrans->lastUseTarget,
+                      newTrans->contTransFlag,
                       newTrans->reverseUseActor,
                       newTrans->reverseUseTarget,
                       newTrans->noUseActor,
@@ -1864,7 +1893,7 @@ void regenerateHumanMadeMap() {
 
 
 TransRecord *getTrans( int inActor, int inTarget, char inLastUseActor,
-                       char inLastUseTarget ) {
+                       char inLastUseTarget, int inContTransFlag ) {
     int mapIndex = inTarget;
     
     if( mapIndex < 0 ) {
@@ -1887,7 +1916,8 @@ TransRecord *getTrans( int inActor, int inTarget, char inLastUseActor,
         
         if( r->actor == inActor && r->target == inTarget &&
             r->lastUseActor == inLastUseActor &&
-            r->lastUseTarget == inLastUseTarget ) {
+            r->lastUseTarget == inLastUseTarget &&
+            r->contTransFlag == inContTransFlag ) {
             return r;
             }
         }
@@ -1910,7 +1940,8 @@ static CustomRandomSource randSource;
 
 TransRecord *getPTrans( int inActor, int inTarget, 
                         char inLastUseActor,
-                        char inLastUseTarget ) {
+                        char inLastUseTarget,
+                        int inContTransFlag ) {
     
     int actorMeta = extractMetadataID( inActor );
     int targetMeta = extractMetadataID( inTarget );
@@ -1923,7 +1954,7 @@ TransRecord *getPTrans( int inActor, int inTarget,
 
 
     TransRecord *r = getTrans( inActor, inTarget, 
-                               inLastUseActor, inLastUseTarget );
+                               inLastUseActor, inLastUseTarget, inContTransFlag );
     
     if( r == NULL ) {
         return r;
@@ -2380,7 +2411,7 @@ char isAncestor( int inTargetID, int inPossibleAncestorID, int inStepLimit ) {
 
 
 static char *getFileName( int inActor, int inTarget, 
-                          char inLastUseActor, char inLastUseTarget ) {
+                          char inLastUseActor, char inLastUseTarget, int inContTransFlag ) {
     const char *lastUseString = "";
     
     if( inLastUseActor && ! inLastUseTarget ) {
@@ -2392,13 +2423,28 @@ static char *getFileName( int inActor, int inTarget,
     else if( inLastUseActor && inLastUseTarget ) {
         lastUseString = "_LA_LT";
         }
+
+    const char *contTransFlagString = "";
     
-    return autoSprintf( "%d_%d%s.txt", inActor, inTarget, lastUseString );
+    if( inContTransFlag == 4 ) {
+        contTransFlagString = "_CONT";
+        }
+    else if( inContTransFlag == 1 ) {
+        contTransFlagString = "_CONTF";
+        }
+    else if( inContTransFlag == 2 ) {
+        contTransFlagString = "_CONTL";
+        }
+    else if( inContTransFlag == 3 ) {
+        contTransFlagString = "_CONTS";
+        }
+    
+    return autoSprintf( "%d_%d%s%s.txt", inActor, inTarget, lastUseString, contTransFlagString );
     }
 
 
 static char *getOldFileName( int inActor, int inTarget, 
-                             char inLastUseActor, char inLastUseTarget ) {
+                             char inLastUseActor, char inLastUseTarget, int inContTransFlag ) {
     const char *lastUseString = "";
     
     if( inLastUseActor && ! inLastUseTarget ) {
@@ -2420,6 +2466,7 @@ void addTrans( int inActor, int inTarget,
                int inNewActor, int inNewTarget,
                char inLastUseActor,
                char inLastUseTarget,
+               int inContTransFlag,
                char inReverseUseActor,
                char inReverseUseTarget,
                char inNoUseActor,
@@ -2485,7 +2532,7 @@ void addTrans( int inActor, int inTarget,
 
     // one exists?
     TransRecord *t = getTrans( inActor, inTarget, 
-                               inLastUseActor, inLastUseTarget );
+                               inLastUseActor, inLastUseTarget, inContTransFlag );
     
     char writeToFile = false;
     
@@ -2505,6 +2552,8 @@ void addTrans( int inActor, int inTarget,
         
         t->lastUseActor = inLastUseActor;
         t->lastUseTarget = inLastUseTarget;
+        
+        t->contTransFlag = inContTransFlag;
 
         t->reverseUseActor = inReverseUseActor;
         t->reverseUseTarget = inReverseUseTarget;
@@ -2638,7 +2687,7 @@ void addTrans( int inActor, int inTarget,
         if( transDir.exists() && transDir.isDirectory() ) {
 
             char *fileName = getFileName( inActor, inTarget, 
-                                          inLastUseActor, inLastUseTarget );
+                                          inLastUseActor, inLastUseTarget, inContTransFlag );
             
 
             File *transFile = transDir.getChildFile( fileName );
@@ -2647,7 +2696,7 @@ void addTrans( int inActor, int inTarget,
 
             // clear old-style file, which may be lingering
             char *oldFileName = getOldFileName( inActor, inTarget, 
-                                             inLastUseActor, inLastUseTarget );
+                                             inLastUseActor, inLastUseTarget, inContTransFlag );
             
 
             File *oldTransFile = transDir.getChildFile( oldFileName );
@@ -2717,11 +2766,12 @@ void addTrans( int inActor, int inTarget,
 void deleteTransFromBank( int inActor, int inTarget,
                           char inLastUseActor,
                           char inLastUseTarget,
+                          int inContTransFlag,
                           char inNoWriteToFile ) {
     
     // one exists?
     TransRecord *t = getTrans( inActor, inTarget, 
-                               inLastUseActor, inLastUseTarget );
+                               inLastUseActor, inLastUseTarget, inContTransFlag );
     
     if( t != NULL ) {
         
@@ -2732,11 +2782,13 @@ void deleteTransFromBank( int inActor, int inTarget,
                 
                 char *fileName = getFileName( inActor, inTarget, 
                                               inLastUseActor,
-                                              inLastUseTarget );
+                                              inLastUseTarget,
+                                              inContTransFlag );
                 
                 char *oldFileName = getOldFileName( inActor, inTarget, 
                                                     inLastUseActor,
-                                                    inLastUseTarget );
+                                                    inLastUseTarget,
+                                                    inContTransFlag );
                 
                 File *transFile = transDir.getChildFile( fileName );
                 File *oldTransFile = transDir.getChildFile( oldFileName );
@@ -2935,6 +2987,9 @@ void printTrans( TransRecord *inTrans ) {
     if( inTrans->lastUseTarget ) {
         printf( " (lastUseTarget)" );
         }
+    if( inTrans->contTransFlag ) {
+        printf( " (contTransFlag)" );
+        }        
     if( inTrans->reverseUseActor ) {
         printf( " (reverseUseActor)" );
         }

--- a/gameSource/transitionBank.h
+++ b/gameSource/transitionBank.h
@@ -29,6 +29,17 @@ typedef struct TransRecord {
         char lastUseActor;
         char lastUseTarget;
         
+        // specially flagged containment transitions
+        
+        // can take values of 0, 1, 2, 3 or 4
+        // 0 meaning not a containment transition
+        // 1 meaning "first", can be "first one in" or "first one out"
+        // depending on whether the container is the actor or the target
+        // 2 meaning "last"
+        // 3 meaning "any except swap"
+        // 4 meaning "any"
+        int contTransFlag;
+        
         // true if this transition undoes a use
         char reverseUseActor;
         char reverseUseTarget;
@@ -104,7 +115,8 @@ void freeTransBank();
 // returns NULL if no trans defined
 TransRecord *getTrans( int inActor, int inTarget, 
                        char inLastUseActor = false,
-                       char inLastUseTarget = false );
+                       char inLastUseTarget = false,
+                       int inContTransFlag = false );
 
 
 // same as getTrans, with actorChangeChance and targetChangeChance applied
@@ -115,7 +127,8 @@ TransRecord *getTrans( int inActor, int inTarget,
 // Also works if newActor or newTarget is a Probability Set Category
 TransRecord *getPTrans( int inActor, int inTarget, 
                         char inLastUseActor = false,
-                        char inLastUseTarget = false );
+                        char inLastUseTarget = false,
+                        int inContTransFlag = false );
 
 
 
@@ -186,6 +199,7 @@ void addTrans( int inActor, int inTarget,
                int inNewActor, int inNewTarget,
                char inLastUseActor,
                char inLastUseTarget,
+               int inContTransFlag,
                char inReverseUseActor,
                char inReverseUseTarget,
                char inNoUseActor,
@@ -206,6 +220,7 @@ void addTrans( int inActor, int inTarget,
 void deleteTransFromBank( int inActor, int inTarget,
                           char inLastUseActor,
                           char inLastUseTarget,
+                          int inContTransFlag,
                           char inNoWriteToFile = false );
 
 


### PR DESCRIPTION
Transitions can now be triggered when player interacts with a container. It can be specified to be triggered when (the first of / the last of / any of but not swapping / any of) (specific / any) object is being (put in/ taken out); and either / both of the container and the object can be transitioned.

For A + B = C + D, if A and C are the containers then this transition is triggered when things are taken out; if B and D are then otherwise. If the objects are left empty, then the transition is triggered when any object is taken out or put in. The "First / Last / Any except Swap / Any" part is specially flagged in the editor.

More details here: https://discord.com/channels/423293333864054833/944170642893316096/963865730758082641