### PR TITLE
Fixed missing water in ocean biome

### DIFF
--- a/server/map.cpp
+++ b/server/map.cpp
@@ -5918,6 +5918,13 @@ int getTweakedBaseMap( int inX, int inY ) {
     char wasGridPlacement = false;
        
     int result = getBaseMap( inX, inY, &wasGridPlacement );
+    
+    int secondPlace;
+    double secondPlaceGap;
+
+    int pickedBiome = getMapBiomeIndex( inX, inY, &secondPlace, &secondPlaceGap );
+    if( biomes[pickedBiome] == 7 ) return result;
+    
  
     if( result > 0 ) {
         ObjectRecord *o = getObject( result );


### PR DESCRIPTION
The map generation has built in a way to "vertical stacking of short objects" which causes empty tiles in the ocean biome.