### PR TITLE
Fix for /DIESEL ENGINE search triggering /DIE command and related 

### DIFF
--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -22447,9 +22447,8 @@ void LivingLifePage::keyDown( unsigned char inASCII ) {
                                 sendToServerSocket( message );
                                 delete [] message;
                                 }
-                            else if( strstr( typedText,
-                                             translate( "dieCommand" ) ) 
-                                     == typedText ) {
+                            else if( !strcmp( typedText,
+                                             translate( "dieCommand" ) ) ) {
                                 // die command issued from baby
                                 char *message = 
                                     autoSprintf( "DIE 0 0#" );
@@ -22457,17 +22456,15 @@ void LivingLifePage::keyDown( unsigned char inASCII ) {
                                 sendToServerSocket( message );
                                 delete [] message;
                                 }
-                            else if( strstr( typedText,
-                                             translate( "fpsCommand" ) ) 
-                                     == typedText ) {
+                            else if( !strcmp( typedText,
+                                             translate( "fpsCommand" ) ) ) {
                                 showFPS = !showFPS;
                                 frameBatchMeasureStartTime = -1;
                                 framesInBatch = 0;
                                 fpsToDraw = -1;
                                 }
-                            else if( strstr( typedText,
-                                             translate( "netCommand" ) ) 
-                                     == typedText ) {
+                            else if( !strcmp( typedText,
+                                             translate( "netCommand" ) ) ) {
                                 showNet = !showNet;
                                 netBatchMeasureStartTime = -1;
                                 messagesInPerSec = -1;
@@ -22479,9 +22476,8 @@ void LivingLifePage::keyDown( unsigned char inASCII ) {
                                 bytesInCount = 0;
                                 bytesOutCount = 0;
                                 }
-                            else if( strstr( typedText,
-                                             translate( "pingCommand" ) ) 
-                                     == typedText ) {
+                            else if( !strcmp( typedText,
+                                             translate( "pingCommand" ) ) ) {
 
                                 waitingForPong = true;
                                 lastPingSent ++;
@@ -22496,9 +22492,8 @@ void LivingLifePage::keyDown( unsigned char inASCII ) {
                                 pongDeltaTime = -1;
                                 pingDisplayStartTime = -1;
                                 }
-                            else if( strstr( typedText,
-                                             translate( "disconnectCommand" ) ) 
-                                     == typedText ) {
+                            else if( !strcmp( typedText,
+                                             translate( "disconnectCommand" ) ) ) {
                                 forceDisconnect = true;
                                 }
                             else {

--- a/gameSource/emotion.cpp
+++ b/gameSource/emotion.cpp
@@ -101,10 +101,9 @@ int getEmotionIndex( const char *inSpeech ) {
     
     for( int i=0; i<emotions.size(); i++ ) {
         
-        if( strstr( upperSpeech, emotions.getElement(i)->triggerWord ) ==
-            upperSpeech ) {
+        if( !strcmp( upperSpeech, emotions.getElement(i)->triggerWord ) ) {
             
-            // starts with trigger
+            // equals trigger word
             delete [] upperSpeech;
             return i;
             }


### PR DESCRIPTION
Fix for https://github.com/twohoursonelife/OneLife/issues/154
**TL;DR** Make commands only trigger on exact match, instead of when command occurs at beginning of typedText 

**What's causing this**
When a command is entered, the is a line to check if it matches the `/DIE` command: 
```if( strstr( typedText, translate( "dieCommand" ) ) == typedText )```
`strstr` check that the command occurs in typedText, and returns the beginning of the match. Comparing the return value with *typedText ensures the match is at the start of typedText. Any texts that comes after this is ignored 

**Jason's fix**
Jason fixed this in this commit: https://github.com/jasonrohrer/OneLife/commit/de536031c4cb979e28d523a1817d444869dc12ef
The commit introduces a new function `commandTyped` that does the following: 
  - Executes the same `strstr` check
  - Trims whitespace from typedText
  - Check that trimmed typedText has the same length as the command text 

**Implementation in this PR**
I replaced the `strstr` substring search with `strcmp` instead of adding the extra `commandTyped` function. This makes sure the command only gets triggered when there is an exact match between the command and the typed text. I added a similar fix to `getEmotionIndex` for `/SADDLE` clashing with `/SAD`, which makes emotions also trigger only on exact matches. If I missed something I'd also be happy to implement the `commandTyped` function instead, but this seemed more straightforward to me. 

**Testing**
I've compiled and tested locally, and checked that `/DIESEL ENGINE` and `/SADDLE` now return the correct search results, and that `/SAD` and `/DIE` also still work. I've tested some other random emotions and verified `/DISCONNECT`, `/PING`, `/FPS` and `/NETWORK` also still work. 

**Remarks**
  - Since we're testing for an exact match, a command with a whitespace at the end will also not match. If we want a bit more flexibility we could call `trimWhitespace` before the `strcmp`.
  - `getEmotionIndex` also changed from match at the beginning to exact string match. It's also used in `EditorScenePage.cpp:644`. I'm not sure if that might cause trouble. 



