### PR TITLE
Set .sh files to use LF line ending

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,7 @@
 # files MUST have Unix line endings in the working directory.
 
 *.txt    text eol=lf
+*.sh     text eol=lf
 
 
 # QCad DXF files are being saved with CRLF


### PR DESCRIPTION
I don't know why this was not a thing already? .sh files will sometimes not work because they have the endings replaced with CRLF. I don't know why anyone would want that.