### PR TITLE
Make VOG allowed accounts case insensitive. Fixes #106

### DIFF
--- a/server/server.cpp
+++ b/server/server.cpp
@@ -15172,13 +15172,17 @@ int main() {
                             SettingsManager::getSetting( 
                                 "vogAllowAccounts" );
                         
+                        char *lowerEmail = stringToLowerCase(nextPlayer->email);
+
                         allow = false;
                         
                         for( int i=0; i<list->size(); i++ ) {
-                            if( strcmp( nextPlayer->email,
-                                        list->getElementDirect( i ) ) == 0 ) {
-                                
+                            char *lowerAllowed = stringToLowerCase(list->getElementDirect( i ));
+                            if( strcmp( lowerEmail,
+                                        lowerAllowed ) == 0 ) {
+
                                 allow = true;
+                                delete [] lowerAllowed;
                                 break;
                                 }
                             else if( strcmp(
@@ -15186,12 +15190,15 @@ int main() {
                                          list->getElementDirect( i ) ) == 0 ) {
                                 // wildcard present in settings file
                                 allow = true;
+                                delete [] lowerAllowed;
                                 break;
                                 }
+                            delete [] lowerAllowed;
                             }
                         
                         list->deallocateStringElements();
                         delete list;
+                        delete [] lowerEmail;
                         }
                     
 


### PR DESCRIPTION
The commit ensures that accounts allowed to enter VOG mode are no longer case sensitive, by converting the player email, and the line from vogAllowAccounts.ini to lowercase before comparison. It uses the stringToLowerCase() function which can be found in minorGems stringUtils. 
https://github.com/twohoursonelife/minorGems/blob/fbd0365bcb2ab3b1daf6c9f278c91a905a0186a1/util/stringUtils.cpp#L59

Tested and working locally as expected. 

I've determined the code structure by comparing to other parts of the code base where this function is used, for consistency.