### PR TITLE
Fix for cursor-tip not updating

### DIFF
--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -18167,6 +18167,11 @@ void LivingLifePage::step() {
                                     }
                                 }
                             }
+
+                        // pretend to move a pointer to the cell if we were hovering it to update the cursor-tip
+                        // if (lastMouseX / CELL_D == mapX && lastMouseY / CELL_D == mapY){
+                            pointerMove(lastMouseX, lastMouseY);
+                            // }
                         }
                     }
                 


### PR DESCRIPTION
So, there's an annoying thing I noticed. When you have an object with uses and are doing things with it (like stacks of items), the cursor-tip doesn't change unless you move your pointer. This bug also happens when the item is removed from the cell entirely.
![screen00023](https://github.com/user-attachments/assets/41b5c07b-2b73-44be-a62a-cecd7f42e035)
![screen00024](https://github.com/user-attachments/assets/243388f3-8167-4c5f-acb9-d7403358c44e)
![screen00025](https://github.com/user-attachments/assets/8c8a291e-b4ac-48b7-b5b7-e260c63a5424)


This happens because mCurMouseOverID is updated only in pointerMove function, and I usually use keyboard, so I don't move pointer between cells.
My solution is calling that pointerMove function after everything in the MAP_CHANGED clause in step() (like someone did for viewChange). I also tried checking whether the cursor is hovering the changed cell but my check for hovered cell is incorrect. It never fires. It's the best I could come up with, after looking at these comments for the lastMouseX
```
// last pos of pointer events, updated by pointerMove, pointerDown etc
// lastMouseX / CELL_D is the actual x coordinate of the tile where the cursor is hovering
```
This works as is but will be better with the check.

Another way to fix this was to update mCurMouseOverID for when the item changes without calling pointerMove. I don't know what would be better.