### PR TITLE
Fix use information in hover tooltips

### DIFF
--- a/gameSource/LivingLifePage.cpp
+++ b/gameSource/LivingLifePage.cpp
@@ -2277,10 +2277,6 @@ std::string LivingLifePage::minitechGetDisplayObjectDescription( int objId ) {
     return description;
     }
 
-static bool isAllDigits( std::string &str ) {
-    return std::all_of(str.begin(), str.end(), ::isdigit);
-    }
-
 // Checks for a potential container change caused by containment transitions
 // We could check all the changed contained objects and all the IN and OUT transitions
 // But it suffices for now to just check for
@@ -11875,7 +11871,7 @@ void LivingLifePage::draw( doublePair inViewCenter,
                         objComment = minitech::getObjDescriptionComment(mCurMouseOverID);
                         }
 
-                    std::string displayedComment = objComment;
+                    std::string displayedComment = "";
                     std::string tagName = " USE";
                     std::string tagData = minitech::getObjDescriptionTagData(objComment, tagName.c_str());
 
@@ -11883,7 +11879,7 @@ void LivingLifePage::draw( doublePair inViewCenter,
                         std::string remainingUseCount = tagData.substr(tagName.size() + 1); 
                         displayedComment = remainingUseCount;
                         }
-                    if( !displayedComment.empty() && isAllDigits(displayedComment) ) {
+                    if( !displayedComment.empty() ) {
                         char *display = autoSprintf("USE: %s", displayedComment.c_str());
                         drawCursorTips( display, {4, -24} );
                         delete [] display;


### PR DESCRIPTION
Show use on hover can sometimes incorrectly show information that is a different part of the object comment, as a number of remaining uses.

### Old behaviour:
- Sets `displayedComment` to the value of `objComment`, then if " USE" is in the comments, it gets that substring and overwrites `displayedComment` to only be the use data.
- Next it adds the uses to the tooltip only if the displayed comment isn't empty and it contains only digits. The assumption is that the only time this will be the case is when the comment has been overwritten by use number, however there are cases in game where comments themselves contain only numbers. The result is these objects incorrectly display as "use 3" etc. when they shouldn't display anything.

### Changes:
- Don't initially set `displayedComment` to `objComment`. This is unnecessary. Set it to an empty string.
- Now the only time `if( !displayedComment.empty() )` will be true is when use information was added to it. No need to check if it's all digits now.


### **Examples**:
Hay bales aren't use based items. Instead each stage is it's own item. A "Hay Bale - 3" for example is the third stage, and can only have 1 more straw added, however uses can be misleading and make it seem like 3 more can be added.
Before:
![image](https://github.com/user-attachments/assets/c0926b74-3291-467f-bf63-ea83c1274940)
After:
![image](https://github.com/user-attachments/assets/de2271c0-fde9-4dfc-a428-0a9e7398a284)

Mines "levels" are identified by numbers in their comments. They are also use based objects. This results in the example, "Coal Mine: Use 3" when the object is first created, followed by an accurate use number after it loses it's first use.
Before:
![image](https://github.com/user-attachments/assets/35b5b8ba-5b83-42a8-a4f8-2ab8b4c45cb1) ![image](https://github.com/user-attachments/assets/9f2bd753-effd-40e1-b9b2-9a524b58c249)
After:
![image](https://github.com/user-attachments/assets/ed445bea-5029-47e5-81e0-35b850032b49) ![image](https://github.com/user-attachments/assets/90145480-d943-47ed-9500-c4f1d69019b1)
