### PR TITLE
Resolve memory leak in map object decay check.

### DIFF
--- a/server/map.cpp
+++ b/server/map.cpp
@@ -5944,7 +5944,8 @@ int checkDecayObject( int inX, int inY, int inID ) {
                     ) {
                         
                     int numContained;
-                    getContained( inX, inY, &numContained );
+                    int *cont = getContained( inX, inY, &numContained );
+                    delete [] cont;
                         
                     if( numContained > 0 ) {
                         


### PR DESCRIPTION
Overloaded function `getContained()` and more specifically `getContainedRaw()` require the caller to free the return value. Leading to a notable memory leak.

I am not familiar with the necessity of calling this function and ignoring the result, though I took the simple route and immediately free'd it after calling it.

Server continues to compile, and brief testing demonstrated the leak was no longer being reported.

Valgrind:
```
==1172== 20 bytes in 2 blocks are definitely lost in loss record 6 of 11
==1172==    at 0x48485C3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1172==    by 0x16C16D: getContainedRaw(int, int, int*, int) (map.cpp:4990)
==1172==    by 0x16C320: getContained(int, int, int*, int) (map.cpp:5053)
==1172==    by 0x16E623: checkDecayObject(int, int, int) (map.cpp:5947)
==1172==    by 0x170050: getMapObject(int, int) (map.cpp:6705)
==1172==    by 0x13809C: main (server.cpp:14753)
==1172==
==1172== 24 bytes in 2 blocks are definitely lost in loss record 7 of 11
==1172==    at 0x48485C3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1172==    by 0x16C16D: getContainedRaw(int, int, int*, int) (map.cpp:4990)
==1172==    by 0x16C320: getContained(int, int, int*, int) (map.cpp:5053)
==1172==    by 0x16E623: checkDecayObject(int, int, int) (map.cpp:5947)
==1172==    by 0x170050: getMapObject(int, int) (map.cpp:6705)
==1172==    by 0x16FE05: lookAtRegion(int, int, int, int) (map.cpp:6623)
==1172==    by 0x138895: main (server.cpp:14984)
==1172==
==1172== 104 bytes in 8 blocks are definitely lost in loss record 8 of 11
==1172==    at 0x48485C3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1172==    by 0x16C16D: getContainedRaw(int, int, int*, int) (map.cpp:4990)
==1172==    by 0x16C320: getContained(int, int, int*, int) (map.cpp:5053)
==1172==    by 0x16E623: checkDecayObject(int, int, int) (map.cpp:5947)
==1172==    by 0x170050: getMapObject(int, int) (map.cpp:6705)
==1172==    by 0x17054B: getChunkMessage(int, int, int, int, GridPos, int*) (map.cpp:6799)
==1172==    by 0x122287: sendMapChunkMessage(LiveObject*, char, int, int) (server.cpp:4451)
==1172==    by 0x14A92E: main (server.cpp:22770)
==1172==
==1172== 3,664 bytes in 468 blocks are definitely lost in loss record 9 of 11
==1172==    at 0x48485C3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1172==    by 0x16C16D: getContainedRaw(int, int, int*, int) (map.cpp:4990)
==1172==    by 0x16C320: getContained(int, int, int*, int) (map.cpp:5053)
==1172==    by 0x16E623: checkDecayObject(int, int, int) (map.cpp:5947)
==1172==    by 0x170084: getMapObjectNoLook(int, int) (map.cpp:6712)
==1172==    by 0x173CA7: getMapChangeRecord(ChangePosition) (map.cpp:8171)
==1172==    by 0x17496F: stepMap(SimpleVector<MapChangeRecord>*, SimpleVector<ChangePosition>*) (map.cpp:8586)
==1172==    by 0x14995D: main (server.cpp:22369)
==1172==
==1172== 1,687,844 bytes in 217,548 blocks are definitely lost in loss record 11 of 11
==1172==    at 0x48485C3: operator new[](unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==1172==    by 0x16C16D: getContainedRaw(int, int, int*, int) (map.cpp:4990)
==1172==    by 0x16C320: getContained(int, int, int*, int) (map.cpp:5053)
==1172==    by 0x16E623: checkDecayObject(int, int, int) (map.cpp:5947)
==1172==    by 0x174779: stepMap(SimpleVector<MapChangeRecord>*, SimpleVector<ChangePosition>*) (map.cpp:8541)
==1172==    by 0x14995D: main (server.cpp:22369)
```