### PR TITLE
Remove OneFile.exe from the repository and add it to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,19 +12,28 @@ leak.out*
 core*
 
 gameSource/OneLife
+gameSource/OneLife.exe
+gameSource/EditOneLife.exe
+gameSource/TownPlanner.exe
 gameSource/testUser/*
 gameSource/testUser2/*
 gameSource/recordedGames/*
 gameSource/screenShots/*
+gameSource/icon.ico
+gameSource/icon.rc
 
 server/OneLifeServer
 server/log.txt
 server/recentPlacements.txt
 server/*.db
 server/backups/
+server/curseLog/
 server/failureLog/
 server/foodLog/
 server/lifeLog/
+server/mapChangeLogs/
 server/categories
 server/objects
 server/transitions
+server/icon.ico
+server/icon.rc


### PR DESCRIPTION
Keeping it there causes problems if you are expecting your new binary to be compiled as "OneLife.exe" but it's compiled as just "OneLife"