### PR TITLE
Remove excessive inconvenient locks of the spawn seed lock

### DIFF
--- a/gameSource/ExistingAccountPage.cpp
+++ b/gameSource/ExistingAccountPage.cpp
@@ -660,14 +660,20 @@ void ExistingAccountPage::makeActive( char inFresh ) {
     
     useSteamUpdate = SettingsManager::getIntSetting( "useSteamUpdate", 0 ) != 0;
     
+    emailFieldLockedMode = 0;
+    keyFieldLockedMode = 0;
+    
+    if (strcmp(mSpawnSeed.getText(), "") == 0) {
+        seedFieldLockedMode = 2;
+        }
+    else {
+        seedFieldLockedMode = 0;
+        }
     
     if( !mFPSMeasureDone || mRetryButton.isVisible() ) {
         
         updateLeftPane();
         
-        emailFieldLockedMode = 0;
-        keyFieldLockedMode = 0;
-        seedFieldLockedMode = 0;
         mEmailField.unfocus();
         mKeyField.unfocus();
         mSpawnSeed.unfocus();
@@ -729,9 +735,6 @@ void ExistingAccountPage::makeActive( char inFresh ) {
         
         updateLeftPane();
         
-        emailFieldLockedMode = 0;
-        keyFieldLockedMode = 0;
-        seedFieldLockedMode = 0;
         mEmailField.unfocus();
         mKeyField.unfocus();
         mSpawnSeed.unfocus();
@@ -966,7 +969,6 @@ void ExistingAccountPage::pointerUp( float inX, float inY ) {
         }
     if( mSpawnSeed.isVisible() && !mSpawnSeed.isMouseOver() ) {
         if( !seedUIElementsClicked ) { // NOT unlock button clicked
-            seedFieldLockedMode = 0;
             mSpawnSeed.unfocus();
             updatefieldsAndLockButtons();
             }


### PR DESCRIPTION
The field used for spawn seed is modified in two ways:
A. Doesn't lock when the seed is blank. There's no need to hide what is empty in the first place.
B. Doesn't lock when clicking away the field. There's no need to hide what has already been revealed.

B isn't problematic because this field is already locked excessively in code. Every time you click next, every time the page is made active, every time it's made inactive and severe other ways.
B is actually what makes sense because the button OK is totally pointless (whether you click on it or outside it locks the fields).