### PR TITLE
Fix issue you can't spawn as a baby to anyone due to incorrect curse level

### DIFF
--- a/server/server.cpp
+++ b/server/server.cpp
@@ -7547,6 +7547,9 @@ int processLoggedInPlayer( char inAllowReconnect,
 
     newObject.lastBabyEmail = NULL;
 
+    newObject.curseStatus = inCurseStatus;
+    newObject.lifeStats = inLifeStats;
+
     newObject.cravingFood = noCraving;
     newObject.cravingFoodYumIncrement = 0;
     newObject.cravingKnown = false;
@@ -8496,8 +8499,6 @@ int processLoggedInPlayer( char inAllowReconnect,
     
     newObject.nameHasSuffix = false;
     newObject.lastSay = NULL;
-    newObject.curseStatus = inCurseStatus;
-    newObject.lifeStats = inLifeStats;
     
     // password-protected objects
     newObject.saidPassword = NULL;


### PR DESCRIPTION
This commit: 47fa16558 relied on lines that where not in the right place as they are in OHOL.
OHOL history: https://github.com/jasonrohrer/OneLife/blob/ad48dc48d62ffcde8a448ca79224e2f9e4b31cb1/server/server.cpp