### PR TITLE
Return of the time bug: Fix 32-bit overflow in lineardb3 offset calculation

### DIFF
--- a/server/lineardb3.cpp
+++ b/server/lineardb3.cpp
@@ -1020,8 +1020,8 @@ static int LINEARDB3_considerFingerprintBucket( LINEARDB3 *inDB,
             
         uint64_t filePosRec = 
             LINEARDB3_HEADER_SIZE +
-            inBucket->fileIndex[ i ] * 
-            inDB->recordSizeBytes;
+            (uint64_t)( inBucket->fileIndex[ i ] ) * 
+            (uint64_t)( inDB->recordSizeBytes );
             
         if( !emptyRec ) {
             
@@ -1227,8 +1227,8 @@ int LINEARDB3_getOrPut( LINEARDB3 *inDB, const void *inKey, void *inOutValue,
 
             uint64_t filePosRec = 
                 LINEARDB3_HEADER_SIZE +
-                newBucket->fileIndex[0] * 
-                inDB->recordSizeBytes;
+                (uint64_t)( newBucket->fileIndex[0] ) * 
+                (uint64_t)( inDB->recordSizeBytes );
 
             // don't seek unless we have to
             if( inDB->lastOp == opRead ||
@@ -1322,7 +1322,7 @@ int LINEARDB3_Iterator_next( LINEARDB3_Iterator *inDBi,
         
         uint64_t fileRecPos = 
             LINEARDB3_HEADER_SIZE + 
-            inDBi->nextRecordIndex * db->recordSizeBytes;
+            (uint64_t)( inDBi->nextRecordIndex ) * (uint64_t)( db->recordSizeBytes );
         
                     
         if( db->lastOp == opWrite ||


### PR DESCRIPTION
This PR addresses a bug that causes mapTime.db to hit a hard cap at ~4.3 GB ( 4,294,967,315 bytes), freezing the decay timers of items on tiles which have not previously recorded a timer. This problem is particularly experienced on long-running maps. In this case, mapTime.db has lasted twice as long as it did when we last ran into a similar problem in #224.

In the lineardb3 engine, the byte offset for a record is calculated as `fileIndex * recordSizeBytes`. Because both variables are 32-bit integers, the multiplication overflows when the file size exceeds 4,294,967,296 bytes. This effectively locked the database from accepting any tiles it had not previously observed a decay timer for. This was sometimes masked by caching of timers in memory, which would often see shorter timers decay successfully so long as they did before it was necessary to evict the timer from cache and save to disk.

Fortunately, lineardb3 has a safety check that compares the calculated offset against the end of the file. Because the overflowed offset didn't match the true EOF, the database safely aborted the write.

Fixed by casting to `uint64_t` prior to multiplication in lineardb3.cpp.